### PR TITLE
Add HTTPS support via HCI_SSL_CERT_FILE and HCI_SSL_KEY_FILE env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,14 @@ HERMES_CONTROL_SECRET=
 # Optional
 
 # Port to listen on. Default: 10272
+# HTTPS support (optional — browsers may force HTTPS on IP addresses).
+# Generate self-signed certs with:
+#   openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -subj "/CN=<your-ip-or-hostname>"
+# Note: SSL_CERT_FILE is a macOS/system reserved variable — use the HCI_ prefix.
+# HCI_SSL_CERT_FILE=/path/to/cert.pem
+# HCI_SSL_KEY_FILE=/path/to/key.pem
+
+# Port to listen on. Default: 10272
 # PORT=10272
 
 # Path to Hermes root directory (file explorer root).

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 require('dotenv').config();
+const https = require('https');
 const express = require('express');
 const helmet = require('helmet');
 const fs = require('fs');
@@ -2281,11 +2282,26 @@ app.post('/api/hermes-cron/:profile/:jobId/:action', requireCsrf, async (req, re
   }
 });
 
-const server = app.listen(PORT, '0.0.0.0', () => {
-  console.log(`Hermes Control Interface running on port ${PORT}`);
-  console.log('Password gate: env-secret only');
-  console.log(`Identity: root@hermes`);
-});
+const server = (() => {
+  const sslCert = process.env.HCI_SSL_CERT_FILE;
+  const sslKey = process.env.HCI_SSL_KEY_FILE;
+  if (sslCert && sslKey && fs.existsSync(sslCert) && fs.existsSync(sslKey)) {
+    const server = https.createServer({
+      cert: fs.readFileSync(sslCert),
+      key: fs.readFileSync(sslKey),
+    }, app);
+    server.listen(PORT, '0.0.0.0', () => {
+      console.log(`Hermes Control Interface running on https://0.0.0.0:${PORT}`);
+    });
+    return server;
+  }
+  const server = app.listen(PORT, '0.0.0.0', () => {
+    console.log(`Hermes Control Interface running on http://0.0.0.0:${PORT}`);
+    console.log('Password gate: env-secret only');
+    console.log(`Identity: root@hermes`);
+  });
+  return server;
+})();
 
 const wss = new WebSocketServer({
   server,


### PR DESCRIPTION
Avoids collision with macOS system SSL_CERT_FILE env var. Includes documentation and self-signed cert generation instructions in .env.example.