### PR TITLE
fix: support HOST env var for non-localhost deployments

### DIFF
--- a/server.js
+++ b/server.js
@@ -2573,8 +2573,8 @@ const server = (() => {
           key: fs.readFileSync(sslKey),
           minVersion: 'TLSv1.2',
         }, app);
-        server.listen(PORT, '127.0.0.1', () => {
-          console.log(`Hermes Control Interface running on https://127.0.0.1:${PORT}`);
+        server.listen(PORT, process.env.HOST || '127.0.0.1', () => {
+          console.log(`Hermes Control Interface running on https://${process.env.HOST || '127.0.0.1'}:${PORT}`);
           console.log('Password gate: env-secret only');
           console.log(`Identity: ${HCI_IDENTITY}`);
         });
@@ -2585,8 +2585,8 @@ const server = (() => {
       }
     }
   }
-  const server = app.listen(PORT, '127.0.0.1', () => {
-    console.log(`Hermes Control Interface running on http://127.0.0.1:${PORT}`);
+  const server = app.listen(PORT, process.env.HOST || '127.0.0.1', () => {
+    console.log(`Hermes Control Interface running on http://${process.env.HOST || '127.0.0.1'}:${PORT}`);
     console.log('Password gate: env-secret only');
     console.log(`Identity: ${HCI_IDENTITY}`);
   });


### PR DESCRIPTION
## Summary

- Both `listen()` calls (HTTPS at L2576 and HTTP at L2588) now read `process.env.HOST`, falling back to `'127.0.0.1'` when unset
- Console log messages reflect the actual bind address instead of always showing `127.0.0.1`

## Motivation

Deploying HCI on a specific network interface (e.g. a Tailscale IP, a LAN-only interface, or `0.0.0.0`) currently requires editing `server.js`. This makes upgrades painful and forks diverge unnecessarily.

With this change, non-localhost deployments work via a single env var:

```env
HOST=10.0.0.5
```

## Test plan

- [ ] `HOST` unset → binds to `127.0.0.1` (default, no behavior change)
- [ ] `HOST=0.0.0.0` → binds to all interfaces
- [ ] `HOST=<specific-ip>` → binds to that IP only
- [ ] Console log shows actual bind address

Tested on a Tailscale-only NixOS deployment.