### PR TITLE
fix: disable upgrade-insecure-requests for HTTP-only deployments

### DIFF
--- a/server.js
+++ b/server.js
@@ -126,6 +126,7 @@ app.use(helmet({
       fontSrc: ["'self'", "https://fonts.gstatic.com"],
       imgSrc: ["'self'", "data:", "blob:", "https://portal.nousresearch.com"],
       connectSrc: ["'self'", "ws:", "wss:"],
+      upgradeInsecureRequests: null,
     },
   },
   hsts: false,


### PR DESCRIPTION
## Summary

- Adds `upgradeInsecureRequests: null` to the helmet CSP directives

## Motivation

Helmet 8.x adds the `upgrade-insecure-requests` CSP directive by default. On HTTP-only deployments (common on LAN, Tailscale, and dev environments), this directive tells the browser to rewrite **all** asset requests (JS, CSS, fonts) to HTTPS.

Since the HCI server is only listening on HTTP in these setups, the browser gets `ERR_SSL_PROTOCOL_ERROR` for every asset — the JS bundle never loads and the UI is completely non-functional (e.g. the login "unlock" button does nothing because no client-side JS is running).

Setting `upgradeInsecureRequests: null` disables the directive, allowing HTTP-only deployments to work correctly. HTTPS deployments are unaffected since their assets are already served over HTTPS.

## Test plan

- [x] HTTP-only deployment: all JS/CSS assets load, login works
- [x] HTTPS deployment: no behavior change (assets already HTTPS)
- [x] Verify no `upgrade-insecure-requests` in response headers on HTTP

Tested on a Tailscale-only NixOS deployment where this was the root cause of a completely blank/non-functional UI.