### PR TITLE
fix: show child sessions in HCI chat lists

### DIFF
--- a/lib/session-list.js
+++ b/lib/session-list.js
@@ -1,0 +1,103 @@
+function normalizeText(value, fallback = '—') {
+  const text = String(value ?? '').trim();
+  return text || fallback;
+}
+
+function previewText(value) {
+  const text = String(value ?? '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return text || '—';
+}
+
+function formatRelativeTime(epochSeconds, nowMs = Date.now()) {
+  const tsMs = Number(epochSeconds || 0) * 1000;
+  if (!Number.isFinite(tsMs) || tsMs <= 0) return '—';
+
+  const diffMs = Math.max(0, nowMs - tsMs);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  if (diffMs < minute) return 'just now';
+  if (diffMs < hour) {
+    const mins = Math.floor(diffMs / minute);
+    return `${mins}m ago`;
+  }
+  if (diffMs < day) {
+    const hours = Math.floor(diffMs / hour);
+    return `${hours}h ago`;
+  }
+  if (diffMs < day * 2) return 'yesterday';
+  const days = Math.floor(diffMs / day);
+  return `${days}d ago`;
+}
+
+function parseHermesSessionsList(raw) {
+  const lines = String(raw || '').split(/\r?\n/).map((line) => line.trimEnd()).filter(Boolean);
+  const dataLines = lines.filter((line) =>
+    !/^Title\s+Preview\s+Last Active\s+ID$/i.test(line) &&
+    !/^[─\-]+$/.test(line) &&
+    !/^(Preview|Title|Last Active|Src)\s+(Preview|Title|Last Active|Src)/i.test(line)
+  );
+
+  return dataLines.map((line) => {
+    const parts = line.trim().split(/\s{2,}/);
+    if (parts.length < 4) return null;
+    const [title, preview, lastActive, id] = parts;
+    return {
+      id: String(id || '').trim(),
+      title: normalizeText(title),
+      preview: previewText(preview),
+      lastActive: normalizeText(lastActive),
+    };
+  }).filter(Boolean);
+}
+
+function mergeSessionsFromSources({ cliSessions = [], dbSessions = [], previewBySessionId = {}, nowMs = Date.now() }) {
+  const merged = new Map();
+
+  for (const session of cliSessions) {
+    if (!session?.id) continue;
+    merged.set(session.id, {
+      id: String(session.id),
+      title: normalizeText(session.title),
+      preview: previewText(session.preview),
+      lastActive: normalizeText(session.lastActive),
+      messageCount: Number(session.messageCount || 0),
+      parentSessionId: session.parentSessionId || null,
+      source: session.source || null,
+      sortTimestamp: Number(session.sortTimestamp || 0),
+    });
+  }
+
+  for (const row of dbSessions) {
+    if (!row?.id) continue;
+    const existing = merged.get(row.id) || {};
+    const sortTimestamp = Number(row.ended_at || row.started_at || existing.sortTimestamp || 0);
+    merged.set(row.id, {
+      ...existing,
+      id: String(row.id),
+      title: normalizeText(row.title, existing.title || '—'),
+      preview: previewText(previewBySessionId[row.id] || existing.preview),
+      lastActive: sortTimestamp ? formatRelativeTime(sortTimestamp, nowMs) : normalizeText(existing.lastActive),
+      messageCount: Number(row.message_count || existing.messageCount || 0),
+      parentSessionId: row.parent_session_id || existing.parentSessionId || null,
+      source: row.source || existing.source || null,
+      sortTimestamp,
+    });
+  }
+
+  return Array.from(merged.values())
+    .sort((a, b) => {
+      if (b.sortTimestamp !== a.sortTimestamp) return b.sortTimestamp - a.sortTimestamp;
+      return String(b.id).localeCompare(String(a.id));
+    })
+    .map(({ sortTimestamp, ...session }) => session);
+}
+
+module.exports = {
+  formatRelativeTime,
+  mergeSessionsFromSources,
+  parseHermesSessionsList,
+};

--- a/server.js
+++ b/server.js
@@ -12,6 +12,11 @@ const pty = require('node-pty');
 const { WebSocketServer } = require('ws');
 const rateLimit = require('express-rate-limit');
 const yaml = require('js-yaml');
+const Database = require('better-sqlite3');
+const {
+  mergeSessionsFromSources,
+  parseHermesSessionsList,
+} = require('./lib/session-list');
 
 // ── LLM Pricing (via @pydantic/genai-prices) ──
 const { calcPrice } = require('@pydantic/genai-prices');
@@ -136,6 +141,7 @@ function clearAuthCookie(res) {
 const CONTROL_HOME = process.env.HERMES_CONTROL_HOME || path.join(os.homedir(), '.hermes');
 const CONTROL_STATE_DIR = path.join(CONTROL_HOME, 'control-interface');
 const AVATAR_OVERRIDE_PATH = path.join(CONTROL_STATE_DIR, 'avatar.dataurl');
+const STATE_DB_PATH = path.join(CONTROL_HOME, 'state.db');
 
 function parseExplorerRoots(raw) {
   if (!raw) return null;
@@ -835,26 +841,6 @@ function getProjects() {
   }
 }
 
-function parseHermesSessionsList(raw) {
-  const lines = String(raw || '').split(/\r?\n/).map((line) => line.trimEnd()).filter(Boolean);
-  const dataLines = lines.filter((line) =>
-    !/^Title\s+Preview\s+Last Active\s+ID$/i.test(line) &&
-    !/^[─\-]+$/.test(line) &&
-    !/^(Preview|Title|Last Active|Src)\s+(Preview|Title|Last Active|Src)/i.test(line)
-  );
-  return dataLines.map((line) => {
-    const parts = line.trim().split(/\s{2,}/);
-    if (parts.length < 4) return null;
-    const [title, preview, lastActive, id] = parts;
-    return {
-      id: String(id || '').trim(),
-      title: String(title || '').trim() || '—',
-      preview: String(preview || '').trim() || '—',
-      lastActive: String(lastActive || '').trim() || '—',
-    };
-  }).filter(Boolean);
-}
-
 function readLayoutStore() {
   try {
     const raw = fs.readFileSync(layoutStorePath, 'utf8');
@@ -1013,13 +999,10 @@ async function getSessions() {
   if (hermesSidebarSessionsCache.data.length && now - hermesSidebarSessionsCache.at < 10_000) {
     return hermesSidebarSessionsCache.data;
   }
-  const raw = await shell('hermes sessions list --limit 10');
-  if (raw) {
-    const data = parseHermesSessionsList(raw);
-    if (data.length) {
-      hermesSidebarSessionsCache = { at: now, data };
-      return data;
-    }
+  const data = await getAllSessions().then((sessions) => sessions.slice(0, 10)).catch(() => []);
+  if (data.length) {
+    hermesSidebarSessionsCache = { at: now, data };
+    return data;
   }
   // Preserve existing cache on error — don't clobber with empty fallback
   if (hermesSidebarSessionsCache.data.length) {
@@ -1035,6 +1018,46 @@ async function getSessions() {
 
 let hermesAllSessionsCache = { at: 0, data: [] };
 
+function getStateDbPath(profile) {
+  return profile && profile !== 'default'
+    ? path.join(os.homedir(), '.hermes', 'profiles', profile, 'state.db')
+    : STATE_DB_PATH;
+}
+
+function loadSessionsFromDb(stateDbPath, limit = 250) {
+  if (!fs.existsSync(stateDbPath)) return { dbSessions: [], previewBySessionId: {} };
+
+  const db = new Database(stateDbPath, { readonly: true });
+  try {
+    const dbSessions = db.prepare(`
+      SELECT id, title, parent_session_id, started_at, ended_at, message_count, source
+      FROM sessions
+      ORDER BY COALESCE(ended_at, started_at) DESC, id DESC
+      LIMIT ?
+    `).all(limit);
+
+    const previewRows = db.prepare(`
+      SELECT session_id, content
+      FROM messages
+      WHERE id IN (
+        SELECT MAX(id)
+        FROM messages
+        WHERE content IS NOT NULL AND TRIM(content) != ''
+        GROUP BY session_id
+      )
+    `).all();
+
+    const previewBySessionId = {};
+    for (const row of previewRows) {
+      previewBySessionId[row.session_id] = row.content;
+    }
+
+    return { dbSessions, previewBySessionId };
+  } finally {
+    db.close();
+  }
+}
+
 async function getAllSessions(profile) {
   const now = Date.now();
   const cacheKey = profile || 'all';
@@ -1044,31 +1067,29 @@ async function getAllSessions(profile) {
   const cmd = profile ? `hermes -p ${profile} sessions list --limit 250` : 'hermes sessions list --limit 250';
   const raw = await shell(cmd);
   if (raw) {
-    const data = parseHermesSessionsList(raw);
-    // Enrich with message counts from state.db
-    try {
-      const stateDbPath = profile && profile !== 'default'
-        ? path.join(os.homedir(), '.hermes', 'profiles', profile, 'state.db')
-        : STATE_DB_PATH;
-      if (fs.existsSync(stateDbPath)) {
-        const db = new Database(stateDbPath, { readonly: true });
-        try {
-          const counts = db.prepare('SELECT id, message_count, title FROM sessions').all();
-          const countMap = {};
-          for (const c of counts) countMap[c.id] = { message_count: c.message_count || 0, dbTitle: c.title };
-          for (const s of data) {
-            const info = countMap[s.id];
-            if (info) {
-              s.messageCount = info.message_count;
-              if ((!s.title || s.title === '—') && info.dbTitle) s.title = info.dbTitle;
-            }
-          }
-        } finally { db.close(); }
-      }
-    } catch {}
+    const cliSessions = parseHermesSessionsList(raw);
+    const stateDbPath = getStateDbPath(profile);
+    const { dbSessions, previewBySessionId } = loadSessionsFromDb(stateDbPath);
+    const data = mergeSessionsFromSources({
+      cliSessions,
+      dbSessions,
+      previewBySessionId,
+      nowMs: now,
+    });
     hermesAllSessionsCache = { at: now, data, key: cacheKey };
     return data;
   }
+
+  try {
+    const stateDbPath = getStateDbPath(profile);
+    const { dbSessions, previewBySessionId } = loadSessionsFromDb(stateDbPath);
+    const data = mergeSessionsFromSources({ dbSessions, previewBySessionId, nowMs: now });
+    if (data.length) {
+      hermesAllSessionsCache = { at: now, data, key: cacheKey };
+      return data;
+    }
+  } catch {}
+
   // No fallback to old cache — return empty if command returned nothing
   return [];
 }
@@ -3068,8 +3089,6 @@ app.get('/api/sessions/:id/export', requireAuth, async (req, res) => {
 });
 
 // Session messages — Phase 1: Message Viewer
-const Database = require('better-sqlite3');
-const STATE_DB_PATH = path.join(CONTROL_HOME, 'state.db');
 
 app.get('/api/sessions/:id/messages', requireAuth, (req, res) => {
   try {

--- a/test/session-list.test.js
+++ b/test/session-list.test.js
@@ -1,0 +1,86 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  mergeSessionsFromSources,
+  parseHermesSessionsList,
+} = require('../lib/session-list');
+
+test('parseHermesSessionsList parses hermes CLI table output', () => {
+  const raw = `Title                            Preview                                  Last Active   ID
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Parent Session                   hello world                              2h ago        parent_123`;
+
+  assert.deepEqual(parseHermesSessionsList(raw), [
+    {
+      id: 'parent_123',
+      title: 'Parent Session',
+      preview: 'hello world',
+      lastActive: '2h ago',
+    },
+  ]);
+});
+
+test('mergeSessionsFromSources keeps child sessions that the CLI omits', () => {
+  const cliSessions = [
+    {
+      id: 'parent_123',
+      title: 'Parent Session',
+      preview: 'original preview',
+      lastActive: '2h ago',
+    },
+  ];
+
+  const dbSessions = [
+    {
+      id: 'child_456',
+      title: 'Renamed child session',
+      parent_session_id: 'parent_123',
+      started_at: 1_710_000_100,
+      ended_at: 1_710_000_400,
+      message_count: 12,
+      source: 'telegram',
+    },
+    {
+      id: 'parent_123',
+      title: 'Parent Session',
+      parent_session_id: null,
+      started_at: 1_709_999_000,
+      ended_at: 1_710_000_000,
+      message_count: 200,
+      source: 'telegram',
+    },
+  ];
+
+  const previewBySessionId = {
+    child_456: 'renamed child preview',
+    parent_123: 'latest parent preview',
+  };
+
+  const merged = mergeSessionsFromSources({
+    cliSessions,
+    dbSessions,
+    previewBySessionId,
+    nowMs: 1_710_000_500_000,
+  });
+
+  assert.equal(merged.length, 2);
+  assert.deepEqual(merged[0], {
+    id: 'child_456',
+    title: 'Renamed child session',
+    preview: 'renamed child preview',
+    lastActive: '1m ago',
+    messageCount: 12,
+    parentSessionId: 'parent_123',
+    source: 'telegram',
+  });
+  assert.deepEqual(merged[1], {
+    id: 'parent_123',
+    title: 'Parent Session',
+    preview: 'latest parent preview',
+    lastActive: '8m ago',
+    messageCount: 200,
+    parentSessionId: null,
+    source: 'telegram',
+  });
+});


### PR DESCRIPTION
## Summary
- merge `hermes sessions list` output with `state.db` session rows so HCI shows child/continued sessions the CLI omits
- use `state.db` as the authoritative source for titles, timestamps, parent session IDs, and message counts
- add regression tests covering the missing-child-session case

## Problem
HCI currently builds the chat/session lists from `hermes sessions list --limit ...` and only enriches those rows with extra metadata from `state.db`.

That breaks for child/continued sessions because Hermes CLI omits them from the list entirely.

Real-world reproduction from my server:
- parent session is visible in the CLI list
- renamed child session exists in `state.db`
- child session never appears in HCI, even after rename, because HCI never receives that row from the CLI in the first place

Example evidence:
```json
{
  "child_session_in_cli_list": false,
  "child_session_db_row": [
    "20260417_130445_7613dc",
    "Syncor IP PR revisions",
    "20260417_084001_cd15fb57"
  ],
  "parent_session_in_cli_list": true
}
```

## Root cause
The current flow is:
1. parse CLI session list
2. enrich existing rows from `state.db`

If a session is missing from step 1, it can never be recovered in step 2.

That makes renamed child sessions effectively invisible in the UI.

## Fix
- extract session-list parsing/merging into `lib/session-list.js`
- load recent sessions directly from `state.db`
- merge CLI rows with DB rows, using DB rows to recover sessions omitted by the CLI
- load latest non-empty message previews from `messages`
- reuse the merged list for both:
  - `/api/all-sessions`
  - the 10-item sidebar session list

This keeps CLI data where it helps, but stops treating the CLI list as the complete source of truth.

## Test plan
```bash
npm test
node --check server.js
```

Added regression coverage for:
- parsing Hermes CLI table output
- preserving a child session that exists in `state.db` but is omitted by the CLI

## Notes
- no tracked frontend files changed
- no behavior change to session rename itself; this fixes discovery/listing of already-renamed child sessions
- I pushed this from a fork because I only have pull access on the upstream repo