### PR TITLE
fix: use persisted session title in chat header

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -3,6 +3,7 @@
    ============================================ */
 import { Chart, registerables } from 'chart.js';
 import { toDisplayText } from './chat-render-utils.mjs';
+import { resolveSessionDisplayTitle } from './session-title-utils.mjs';
 Chart.register(...registerables);
 
 // State
@@ -426,7 +427,9 @@ async function loadChatSession(sessionId) {
     const r = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/messages?profile=${encodeURIComponent(profile)}`, { credentials: 'include' });
     if (!r.ok) { container.innerHTML = '<div class="error-msg">Failed to load messages</div>'; return; }
     const data = await r.json();
-    if (titleEl) titleEl.textContent = toDisplayText(data.title ?? ('Session ' + sessionId));
+    if (titleEl) {
+      titleEl.textContent = toDisplayText(resolveSessionDisplayTitle({ sessionId, data }));
+    }
     if (subtitleEl) subtitleEl.textContent = `${data.messages?.length || 0} messages · ${profile}`;
 
     // Token info

--- a/src/js/session-title-utils.mjs
+++ b/src/js/session-title-utils.mjs
@@ -1,0 +1,9 @@
+export function resolveSessionDisplayTitle({ sessionId, data }) {
+  const persistedTitle = data?.session?.title;
+
+  if (persistedTitle && persistedTitle !== '—') {
+    return persistedTitle;
+  }
+
+  return sessionId;
+}

--- a/test/session-title-utils.test.js
+++ b/test/session-title-utils.test.js
@@ -1,0 +1,50 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+async function loadUtils() {
+  return import('../src/js/session-title-utils.mjs');
+}
+
+test('resolveSessionDisplayTitle prefers the persisted session title from the messages payload', async () => {
+  const { resolveSessionDisplayTitle } = await loadUtils();
+
+  assert.equal(
+    resolveSessionDisplayTitle({
+      sessionId: '20260417_130445_7613dc',
+      data: {
+        session: {
+          title: 'Syncor IP PR revisions',
+        },
+      },
+    }),
+    'Syncor IP PR revisions'
+  );
+});
+
+test('resolveSessionDisplayTitle falls back to the session id when the persisted title is blank or em dash', async () => {
+  const { resolveSessionDisplayTitle } = await loadUtils();
+
+  assert.equal(
+    resolveSessionDisplayTitle({
+      sessionId: '20260414_075004_676472',
+      data: {
+        session: {
+          title: '—',
+        },
+      },
+    }),
+    '20260414_075004_676472'
+  );
+
+  assert.equal(
+    resolveSessionDisplayTitle({
+      sessionId: '20260414_075004_676472',
+      data: {
+        session: {
+          title: '',
+        },
+      },
+    }),
+    '20260414_075004_676472'
+  );
+});


### PR DESCRIPTION
## Bug Description

The chat sidebar could show the real persisted session title while the main chat header fell back to `Session <id>` for the same conversation.

## Root Cause

The sidebar reads session titles from the sessions list payload, but the chat header was looking for `data.title` on the messages response. The messages endpoint actually returns the persisted title at `data.session.title`.

## Fix

- add a small `resolveSessionDisplayTitle()` helper for chat header title selection
- use the persisted `data.session.title` when present
- fall back to the session id when the persisted title is blank or `—`
- add regression tests for both the persisted-title and fallback cases

## How to Verify

1. Open a conversation whose sidebar title differs from its raw session id
2. Click it in the chat sidebar
3. Confirm the main chat header shows the same human title as the sidebar instead of `Session <id>`

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass (`npm test`)
- [x] Manual verification of the fix on the live server

## Risk Assessment

Low — the change only affects chat header title selection and keeps the existing id fallback for untitled sessions.
