### PR TITLE
fix: sessions list loading — parser dual-format + missing await

### DIFF
--- a/lib/session-list.js
+++ b/lib/session-list.js
@@ -35,6 +35,13 @@ function formatRelativeTime(epochSeconds, nowMs = Date.now()) {
 
 function parseHermesSessionsList(raw) {
   const lines = String(raw || '').split(/\r?\n/).map((line) => line.trimEnd()).filter(Boolean);
+
+  // Detect header format: "Title Preview Last Active ID" vs "Preview Last Active Src ID"
+  let hasTitleCol = false;
+  for (const line of lines) {
+    if (/^Title\s+Preview\s+Last Active\s+ID/i.test(line)) { hasTitleCol = true; break; }
+  }
+
   const dataLines = lines.filter((line) =>
     !/^Title\s+Preview\s+Last Active\s+ID$/i.test(line) &&
     !/^[─\-]+$/.test(line) &&
@@ -42,14 +49,55 @@ function parseHermesSessionsList(raw) {
   );
 
   return dataLines.map((line) => {
+    // Split on 2+ spaces — safe for first 2-3 columns
     const parts = line.trim().split(/\s{2,}/);
-    if (parts.length < 4) return null;
-    const [title, preview, lastActive, id] = parts;
+
+    let title, preview, lastActive, source, id;
+
+    if (hasTitleCol) {
+      // Format: Title | Preview | Last Active | ID (no Source)
+      if (parts.length < 3) return null;
+      if (parts.length === 4) {
+        [title, preview, lastActive, id] = parts;
+      } else if (parts.length === 3) {
+        // Cramped: "title preview" | lastActive | id
+        const lastTokens = parts[2].trim().split(/\s+/);
+        if (lastTokens.length >= 2) {
+          title = parts[0];
+          preview = parts[1];
+          lastActive = lastTokens.slice(0, -1).join(' ');
+          id = lastTokens[lastTokens.length - 1];
+        } else {
+          [title, preview, lastActive] = parts;
+          id = lastTokens[0];
+        }
+      }
+      source = null;
+    } else {
+      // Format: Preview | Last Active | Src | ID
+      if (parts.length < 3) return null;
+      const lastPart = parts[parts.length - 1];
+      const lastTokens = lastPart.trim().split(/\s+/);
+
+      if (parts.length === 4) {
+        [preview, lastActive, source, id] = parts;
+      } else if (parts.length === 3 && lastTokens.length >= 2) {
+        // Cramped: preview | lastActive | "source id"
+        [preview, lastActive] = parts;
+        source = lastTokens.slice(0, -1).join(' ');
+        id = lastTokens[lastTokens.length - 1];
+      } else {
+        return null;
+      }
+      title = preview;
+    }
+
     return {
       id: String(id || '').trim(),
       title: normalizeText(title),
       preview: previewText(preview),
       lastActive: normalizeText(lastActive),
+      source: source || null,
     };
   }).filter(Boolean);
 }

--- a/server.js
+++ b/server.js
@@ -1954,9 +1954,9 @@ app.get('/api/dashboard-state', requireAuth, async (req, res) => {
   res.json(await buildDashboardState(true));
 });
 
-app.get('/api/sessions', requireAuth, (req, res) => {
+app.get('/api/sessions', requireAuth, async (req, res) => {
   // Short list for sidebar — limit 10, cached 10s
-  const data = getSessions();
+  const data = await getSessions();
   res.json({ sessions: data, cachedAt: hermesSidebarSessionsCache.at });
 });
 


### PR DESCRIPTION
## Fixes
- parseHermesSessionsList: handle two CLI output formats (Title|Preview|Last Active|ID vs Preview|Last Active|Src|ID)
- Handle cramped columns when preview text is short
- Fix missing 'await' on getSessions() in /api/sessions handler

## Root Cause
- CLI output format changes based on --limit value
- Promise was serialized to {} instead of resolved array

Tested on both staging and prod — sessions loading correctly.