### PR TITLE
fix: align auth flow docs and macOS runtime support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,15 +8,15 @@
 
 # Required
 
-# Password for the login screen. Use a long random string in production.
-# Generate one with: openssl rand -hex 32
-HERMES_CONTROL_PASSWORD=
-
 # HMAC secret for signing auth tokens and internal request verification.
 # Generate one with: openssl rand -hex 32
-HERMES_CONTROL_SECRET=
+HERMES_CONTROL_SECRET=***
 
 # Optional
+
+# Legacy bootstrap password from the pre-user-store auth model.
+# No longer used by the current multi-user flow.
+# HERMES_CONTROL_PASSWORD=
 
 # Port to listen on. Default: 10272
 # PORT=10272

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,10 +17,14 @@ Thanks for your interest in contributing! This guide will help you get started.
 4. Copy the example config:
    ```bash
    cp .env.example .env
-   # Edit .env with your HERMES_CONTROL_PASSWORD and HERMES_CONTROL_SECRET
+   # Edit .env with your HERMES_CONTROL_SECRET
    ```
-5. Start the dev server:
+5. Start the app for development:
    ```bash
+   # Terminal 1
+   npm start
+
+   # Terminal 2
    npm run dev
    ```
 
@@ -42,12 +46,14 @@ Thanks for your interest in contributing! This guide will help you get started.
 
 ```
 hermes-control-interface/
-├── server.js          # Express server, auth, PTY, WebSocket, APIs
-├── website/           # Frontend (vanilla JS, xterm.js)
-│   ├── app.js         # Main client-side logic
+├── server.js          # Express server, PTY, WebSocket, APIs
+├── auth.js            # Password + multi-user auth helpers
+├── src/               # Vite frontend source
 │   ├── index.html     # Dashboard HTML
-│   ├── styles.css     # Styles
-│   └── favicon.svg    # Favicon
+│   ├── js/main.js     # Main client-side logic
+│   ├── css/           # Theme, layout, components
+│   └── assets/        # SVG/icons
+├── dist/              # Built frontend served by Express
 ├── docs/              # Documentation
 ├── .env.example       # Config template
 ├── install.sh         # Interactive setup script

--- a/README.md
+++ b/README.md
@@ -136,8 +136,7 @@ npm install
 # Configure
 cp .env.example .env
 # Edit .env:
-#   HERMES_CONTROL_PASSWORD=your-password
-#   HERMES_CONTROL_SECRET=your-secret
+#   HERMES_CONTROL_SECRET=your-random-secret
 
 # Build frontend
 npx vite build
@@ -148,12 +147,14 @@ npm start
 
 Access at `http://localhost:10272` (default PORT).
 
+On a clean install, the web UI prompts you to create the first admin account.
+
 ## Environment Variables
 
 | Variable | Required | Description |
 |---|---|---|
-| `HERMES_CONTROL_PASSWORD` | Yes | Login password |
-| `HERMES_CONTROL_SECRET` | Yes | CSRF + internal auth secret |
+| `HERMES_CONTROL_SECRET` | Yes | Auth token signing secret |
+| `HERMES_CONTROL_PASSWORD` | No | Legacy env password from pre-user-store auth |
 | `PORT` | No | Server port (default: 10272) |
 | `HERMES_CONTROL_HOME` | No | Hermes home dir (default: ~/.hermes) |
 | `HERMES_CONTROL_ROOTS` | No | File explorer roots (JSON array) |
@@ -179,11 +180,22 @@ auth.js                 # Multi-user auth system
 ## Development
 
 ```bash
-# Edit source in src/
-# Build
-npx vite build
-# Restart (never in foreground — use detached)
-kill $(lsof -t -i:10274) 2>/dev/null; sleep 1; nohup node server.js &>/dev/null & disown
+# Terminal 1: backend API on the default app port
+npm start
+
+# Terminal 2: Vite dev server for frontend changes
+npm run dev
+```
+
+- Backend default: `http://localhost:10272`
+- Frontend dev server: `http://localhost:5173`
+- To point the frontend at a different backend, set `HCI_BACKEND_URL` before `npm run dev`
+
+For production/static serving, rebuild the frontend and restart the backend:
+
+```bash
+npm run build
+npm start
 ```
 
 ## API

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@ Base URL: `http://localhost:10272` (or your domain if behind a reverse-proxy)
 
 All endpoints marked **Auth required** require a valid session cookie (`hermes...auth`).
 
-Login first via `POST /api/login` to receive the cookie.
+Login first via `POST /api/auth/setup` on a fresh install, then `POST /api/auth/login` to receive the cookie.
 
 Internal endpoints (marked **Internal**) require the `x-hermes-control-secret` header matching `HERMES_CONTROL_SECRET` instead of a cookie.
 
@@ -49,7 +49,7 @@ Returns the current authentication state.
 
 ---
 
-### `POST /api/login`
+### `POST /api/auth/login`
 
 **Auth required:** No
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -8,21 +8,20 @@ Hermes Control Interface is configured entirely through environment variables.
 
 ## Required Variables
 
-### `HERMES_CONTROL_PASSWORD`
-
-Login password for the dashboard. There is no default — if this is not set the server refuses to start.
-
-Use a long random string in production:
-```bash
-openssl rand -hex 32
-```
-
 ### `HERMES_CONTROL_SECRET`
 
 HMAC secret for signing auth tokens and verifying internal requests. Must be set. Generate with:
 ```bash
 openssl rand -hex 32
 ```
+
+---
+
+## First-Run Auth Setup
+
+On a clean install, the web UI prompts you to create the first admin account and stores it in `~/.hermes/hci-users.json`.
+
+The old `HERMES_CONTROL_PASSWORD` env var is no longer used by the current multi-user flow.
 
 ---
 
@@ -88,10 +87,10 @@ If not set, defaults to `[HERMES_CONTROL_HOME]` (i.e. `/root/.hermes`).
 
 ## Verifying Your Config
 
-The server validates required variables on startup. If `HERMES_CONTROL_PASSWORD` or `HERMES_CONTROL_SECRET` is missing, it exits immediately with:
+The server validates required variables on startup. If `HERMES_CONTROL_SECRET` is missing, it exits immediately with:
 
 ```
-Error: Missing HERMES_CONTROL_PASSWORD or HERMES_CONTROL_SECRET environment variables
+Error: Missing HERMES_CONTROL_SECRET environment variable
 ```
 
 To check if your `.env` is loading correctly, start the server and look for:

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -21,8 +21,7 @@ cp .env.example .env
 
 Edit `.env`:
 ```bash
-HERMES_CONTROL_PASSWORD=<generate with: openssl rand -hex 32>
-HERMES_CONTROL_SECRET=<generate with: openssl rand -hex 32>
+HERMES_CONTROL_SECRET=$(openssl rand -hex 32)
 ```
 
 Verify it starts:
@@ -126,12 +125,11 @@ Wants=network-online.target
 [Service]
 Type=simple
 WorkingDirectory=/path/to/hermes-control-interface
+EnvironmentFile=/path/to/hermes-control-interface/.env
+Environment=NODE_ENV=production
 ExecStart=/usr/bin/node server.js
 Restart=always
 RestartSec=10
-Environment=NODE_ENV=production
-# Environment=HERMES_CONTROL_PASSWORD=your-p...here
-# Environment=HERMES_CONTROL_SECRET=***
 
 # Run as non-root user (recommended for production)
 # Create the user first: sudo useradd -r -s /bin/false hermes
@@ -153,7 +151,7 @@ sudo systemctl status hermes-control
 
 ## Step 5 — Verify
 
-Open `https://hermes.example.com` in your browser. You should see the login screen. Log in with your configured password.
+Open `https://hermes.example.com` in your browser. On a fresh install, create the first admin account in the web UI, then log in with that account.
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -20,7 +20,6 @@ npm install
 
 Edit `.env` and set:
 
-- `HERMES_CONTROL_PASSWORD`
 - `HERMES_CONTROL_SECRET`
 - `PORT` if you want a different port
 - `HERMES_CONTROL_HOME` if your Hermes state lives somewhere else
@@ -33,5 +32,7 @@ npm start
 ```
 
 Open `http://127.0.0.1:10272` in your browser.
+
+On a clean install, the web UI prompts you to create the first admin account.
 
 If you want to expose the app beyond localhost, put it behind a reverse proxy and TLS. Do not publish the raw port without a plan.

--- a/docs/PASSWORD.md
+++ b/docs/PASSWORD.md
@@ -1,65 +1,40 @@
 # Password Management
 
-## How It Works
+## Current Auth Model
 
-HCI stores the dashboard password in `.env` as `HERMES_CONTROL_PASSWORD`.
+The current HCI auth flow stores dashboard users in `~/.hermes/hci-users.json`.
 
-The password can be stored in two formats:
+On first run, the UI prompts you to create the first admin account. Passwords are stored as bcrypt hashes in that user store.
 
-### Bcrypt Hashed (Recommended)
-```
-HERMES_CONTROL_PASSWORD=$2b$10$xJ8kL3mN9pQ2rS5tU7vW1y...
-```
-- Starts with `$2b$` or `$2a$`
-- Compared using `bcrypt.compareSync()` — timing-safe, irreversible
-- If `.env` leaks, attacker cannot recover the password
+`HERMES_CONTROL_SECRET` in `.env` is still required for signing auth tokens and internal request verification.
 
-### Plaintext (Legacy)
-```
-HERMES_CONTROL_PASSWORD=mysecretpassword123
-```
-- Compared using `crypto.timingSafeEqual()` — timing-safe but reversible
-- If `.env` leaks, attacker can read the password directly
-
-The server auto-detects which format is used on login.
-
----
-
-## First-Time Setup
-
-When you run `bash install.sh`:
-1. A random 24-character password is generated
-2. It's hashed with bcrypt (10 rounds)
-3. The hash is saved to `.env`
-4. The plaintext password is shown ONCE — **save it somewhere safe**
-
-If bcrypt is not available (e.g., `npm install` hasn't finished), the password is saved as plaintext. Run `bash reset-password.sh` later to hash it.
+`HERMES_CONTROL_PASSWORD` is a legacy env var from the pre-user-store auth model and is no longer used by the current multi-user flow.
 
 ---
 
 ## Reset Password
 
-### Option 1 — Interactive (asks for password)
+### Option 1 — Interactive (asks for username and password)
 ```bash
 cd hermes-control-interface
 bash reset-password.sh
 ```
 
-### Option 2 — Direct (pass password as argument)
+### Option 2 — Direct
 ```bash
-bash reset-password.sh "my-new-password"
+bash reset-password.sh username "my-new-password"
 ```
 
 ### Option 3 — Via npm
 ```bash
-npm run reset-password
+npm run reset-password -- username "my-new-password"
 ```
 
 ### What happens:
-1. You enter a new password
-2. It's hashed with bcrypt (10 rounds)
-3. The hash replaces `HERMES_CONTROL_PASSWORD` in `.env`
-4. Restart the server for changes to take effect
+1. You choose a target username
+2. The new password is hashed with bcrypt (10 rounds)
+3. The matching user's `password_hash` is updated in `~/.hermes/hci-users.json`
+4. Existing sessions continue until logout or secret rotation
 
 ### After reset:
 ```bash
@@ -72,14 +47,11 @@ sudo systemctl restart hermes-control
 
 ---
 
-## Check Current Password Format
+## Check Current Users
 
 ```bash
-grep HERMES_CONTROL_PASSWORD .env
+cat ~/.hermes/hci-users.json
 ```
-
-- Starts with `$2b$` or `$2a$` → bcrypt hashed (secure)
-- Anything else → plaintext (run `reset-password.sh` to hash)
 
 ---
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,16 +2,16 @@
 
 ## Authentication
 
-**Password storage:** Plaintext comparison against the value in `HERMES_CONTROL_PASSWORD`. The password itself is never stored — only the live environment variable. Use a long, random value in production.
+**Password storage:** Dashboard users are stored in `~/.hermes/hci-users.json` with bcrypt password hashes. Plaintext passwords are not stored.
 
-**Password comparison:** Uses `crypto.timingSafeEqual` to prevent timing oracle attacks. This eliminates timing side-channels in the comparison itself.
+**Password comparison:** Uses `bcrypt.compareSync()` against the stored password hash.
 
 **Auth tokens:** HMAC-SHA256 signed tokens stored in an HttpOnly cookie. Tokens contain a Unix timestamp and are valid for 24 hours. The signature prevents tampering or forgery.
 
 **Rate limiting:** IPs are blocked from authenticating after 5 failed attempts within a 15-minute window. This does not prevent brute-force attacks entirely but significantly raises the cost.
 
 **Weaknesses:**
-- Single shared password — no per-user isolation
+- Local filesystem user store (no external identity provider)
 - No MFA
 - No login attempt notification (could silently tolerate brute force if attacker has enough time)
 
@@ -51,14 +51,14 @@ The `/ws` endpoint requires an authenticated session cookie. Unauthenticated Web
 
 ## What This Is Not
 
-- **Not multi-user.** All browser sessions share the same password. Treat it like a root password.
+- **Not enterprise identity.** Users are managed in a local JSON store, not LDAP/OIDC/SAML.
 - **Not hardened for hostile networks.** Designed for trusted LANs or HTTPS-reverse-proxied deployments.
 - **Not audited.** This analysis is a surface-level review, not a formal security audit.
 
 ## Recommendations for Production
 
 1. **Use HTTPS.** Always. Either behind an nginx reverse-proxy or on a platform that provides TLS.
-2. **Use a strong, randomly generated password.** Minimum 32 characters.
+2. **Use strong per-user passwords.** Minimum 8 characters; longer is better.
 3. **Rotate secrets periodically.** A rotated `HERMES_CONTROL_SECRET` invalidates all existing sessions.
 4. **Don't expose to the public internet** without a reverse-proxy and rate limiting.
 5. **Consider IP allowlisting** at the firewall or nginx level if access is limited to specific IPs.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -15,7 +15,7 @@ git clone https://github.com/xaspx/hermes-control-interface.git
 cd hermes-control-interface
 npm install
 cp .env.example .env
-# Edit .env — set HERMES_CONTROL_PASSWORD and HERMES_CONTROL_SECRET
+# Edit .env — set HERMES_CONTROL_SECRET
 npm start
 ```
 
@@ -25,13 +25,13 @@ See [README Quick Start](../README.md#quick-start) for details.
 
 ## Server won't start
 
-### `Error: Missing HERMES_CONTROL_PASSWORD or HERMES_CONTROL_SECRET environment variables`
+### `Error: Missing HERMES_CONTROL_SECRET environment variable`
 
-The `.env` file is missing or those variables are empty.
+The `.env` file is missing or `HERMES_CONTROL_SECRET` is empty.
 
 ```bash
 cp .env.example .env
-# Edit .env and fill in both values
+# Edit .env and fill in HERMES_CONTROL_SECRET
 npm start
 ```
 
@@ -73,13 +73,9 @@ node -v  # should be v20.x.x or higher
 
 ### Login form returns 401
 
-Wrong password. Check the value in `.env`:
+Wrong username or password.
 
-```bash
-grep HERMES_CONTROL_PASSWORD .env
-```
-
-There is no way to recover a lost password except by setting a new one in `.env`.
+If you have admin access through another account, reset the user's password in the UI. Otherwise use the CLI reset script documented in `docs/PASSWORD.md`.
 
 ### Login appears to succeed but immediately asks for password again
 

--- a/install.sh
+++ b/install.sh
@@ -51,38 +51,18 @@ else
 
   cp .env.example .env
 
-  # Generate secure secrets
-  if grep -q '^HERMES_CONTROL_PASSWORD=\*\*\*' .env 2>/dev/null; then
-    NEW_PASS=$(openssl_rand | cut -c1-24)
-    # Hash with bcrypt and save
-    HASHED=$(node -e "require('bcrypt').hashSync('${NEW_PASS}', 10)" 2>/dev/null || echo "")
-    if [[ -n "$HASHED" ]]; then
-      sed -i "s|^HERMES_CONTROL_PASSWORD=.*|HERMES_CONTROL_PASSWORD=${HASHED}|" .env
-      info "Generated and hashed HERMES_CONTROL_PASSWORD"
-      echo ""
-      warn "SAVE THIS PASSWORD — it will NOT be shown again:"
-      echo -e "  ${BOLD}${NEW_PASS}${RESET}"
-      echo ""
-    else
-      # Fallback: save plaintext (user must run reset-password.sh later)
-      sed -i "s|^HERMES_CONTROL_PASSWORD=.*|HERMES_CONTROL_PASSWORD=${NEW_PASS}|" .env
-      warn "bcrypt not available — password saved as plaintext"
-      warn "Run 'bash reset-password.sh' after install to hash it"
-      echo ""
-      warn "SAVE THIS PASSWORD:"
-      echo -e "  ${BOLD}${NEW_PASS}${RESET}"
-      echo ""
-    fi
+  if grep -q '^HERMES_CONTROL_SECRET=' .env 2>/dev/null; then
+    info ".env template copied"
   fi
 
-  if grep -q '^HERMES_CONTROL_SECRET=\*\*\*' .env 2>/dev/null; then
-    NEW_SECRET=$(uuid4 | cut -c1-64)
-    sed -i "s|^HERMES_CONTROL_SECRET=.*|HERMES_CONTROL_SECRET=${NEW_SECRET}|" .env
+  if grep -q '^HERMES_CONTROL_SECRET=***' .env 2>/dev/null; then
+    NEW_SECRET=$(openssl_rand | cut -c1-64)
+    perl -0pi -e 's/^HERMES_CONTROL_SECRET=.*/HERMES_CONTROL_SECRET='"${NEW_SECRET}"'/m' .env
     info "Generated HERMES_CONTROL_SECRET"
   fi
 
   chmod 600 .env
-  info ".env created — edit it to set your password and secrets"
+  info ".env created — edit it if you want to change defaults"
 fi
 
 # ── 4. Nginx reverse-proxy (optional) ─────────────────────────────────────────
@@ -208,10 +188,10 @@ echo "  1. Start the server:"
 echo "     npm start"
 echo ""
 echo "  2. Open the dashboard:"
-echo "     http://$(hostname -I | awk '{print $1}'):10272"
+LOCAL_IP=$(node -e 'const os=require("os"); const nets=os.networkInterfaces(); for (const entries of Object.values(nets)) { for (const entry of (entries || [])) { if (entry && entry.family === "IPv4" && !entry.internal) { console.log(entry.address); process.exit(0); } } } console.log("127.0.0.1");')
+echo "     http://${LOCAL_IP}:10272"
 echo ""
-echo "  To reset password later:"
-echo "     bash reset-password.sh"
+echo "  3. On first run, create the first admin account in the web UI"
 echo ""
 echo "  For HTTPS + auto-start, enable the systemd service."
 echo ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-control-interface",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-control-interface",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",

--- a/reset-password.sh
+++ b/reset-password.sh
@@ -39,7 +39,9 @@ fi
 
 echo ""
 
-if [[ $# -ge 1 ]]; then
+if [[ $# -ge 2 ]]; then
+  node scripts/reset-password.js "$1" "$2"
+elif [[ $# -ge 1 ]]; then
   node scripts/reset-password.js "$1"
 else
   node scripts/reset-password.js

--- a/scripts/reset-password.js
+++ b/scripts/reset-password.js
@@ -2,63 +2,41 @@
 'use strict';
 
 const bcrypt = require('bcrypt');
-const fs = require('fs');
-const path = require('path');
 const readline = require('readline');
+const { loadUsers, saveUsers, findUser } = require('../auth');
 
 const SALT_ROUNDS = 10;
-const ENV_PATH = path.resolve(__dirname, '..', '.env');
 
 function hashPassword(plain) {
   return bcrypt.hashSync(plain, SALT_ROUNDS);
 }
 
-function updateEnvFile(hashedPassword) {
-  let envContent = '';
-  try {
-    envContent = fs.readFileSync(ENV_PATH, 'utf8');
-  } catch (err) {
-    console.error(`Error reading .env file: ${err.message}`);
+function updateUserPassword(username, hashedPassword) {
+  const data = loadUsers();
+  const user = data.users.find((entry) => entry.username === username);
+  if (!user) {
+    console.error(`Error: User not found: ${username}`);
     process.exit(1);
   }
-
-  const lines = envContent.split('\n');
-  let found = false;
-  const updated = lines.map((line) => {
-    if (line.startsWith('HERMES_CONTROL_PASSWORD=')) {
-      found = true;
-      return `HERMES_CONTROL_PASSWORD=${hashedPassword}`;
-    }
-    return line;
-  });
-
-  if (!found) {
-    updated.push(`HERMES_CONTROL_PASSWORD=${hashedPassword}`);
-  }
-
-  fs.writeFileSync(ENV_PATH, updated.join('\n'), 'utf8');
+  user.password_hash = hashedPassword;
+  saveUsers(data);
 }
 
-function printConfirmation(hashedPassword) {
+function printConfirmation(username) {
   console.log('');
   console.log('Password has been updated and hashed with bcrypt.');
-  console.log('');
-  console.log('Hashed value written to .env:');
-  console.log(`  HERMES_CONTROL_PASSWORD=${hashedPassword}`);
-  console.log('');
-  console.log('Restart the server for changes to take effect:');
-  console.log('  sudo systemctl restart hermes-control');
+  console.log(`Updated user: ${username}`);
   console.log('');
 }
 
-async function promptPassword() {
+async function prompt(question) {
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
   });
 
   return new Promise((resolve) => {
-    rl.question('Enter new password: ', (answer) => {
+    rl.question(question, (answer) => {
       rl.close();
       resolve(answer);
     });
@@ -66,24 +44,33 @@ async function promptPassword() {
 }
 
 async function main() {
-  const arg = process.argv[2];
+  const usernameArg = process.argv[2];
+  const passwordArg = process.argv[3];
 
-  let newPassword;
-  if (arg) {
-    newPassword = arg;
-  } else {
-    newPassword = await promptPassword();
+  const username = (usernameArg || await prompt('Username to reset: ')).trim();
+  if (!username) {
+    console.error('Error: Username cannot be empty.');
+    process.exit(1);
+  }
+  if (!findUser(username)) {
+    console.error(`Error: User not found: ${username}`);
+    process.exit(1);
   }
 
+  const newPassword = passwordArg || await prompt('Enter new password: ');
   if (!newPassword || newPassword.trim() === '') {
     console.error('Error: Password cannot be empty.');
+    process.exit(1);
+  }
+  if (newPassword.trim().length < 8) {
+    console.error('Error: Password must be at least 8 characters.');
     process.exit(1);
   }
 
   console.log('Hashing password with bcrypt (10 rounds)...');
   const hashed = hashPassword(newPassword.trim());
-  updateEnvFile(hashed);
-  printConfirmation(hashed);
+  updateUserPassword(username, hashed);
+  printConfirmation(username);
 }
 
 main().catch((err) => {

--- a/server.js
+++ b/server.js
@@ -13,13 +13,26 @@ const rateLimit = require('express-rate-limit');
 const yaml = require('js-yaml');
 
 // Async shell execution utility (non-blocking)
+function parseShellTimeout(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  const raw = String(value || '8s').trim();
+  const match = raw.match(/^(\d+)(ms|s|m)?$/i);
+  if (!match) return 8000;
+  const amount = Number(match[1]);
+  const unit = (match[2] || 'ms').toLowerCase();
+  if (unit === 'm') return amount * 60_000;
+  if (unit === 's') return amount * 1_000;
+  return amount;
+}
+
 function shell(cmd, timeout = '8s') {
   return new Promise((resolve) => {
-    execFile('bash', ['-lc', `timeout ${timeout} ${cmd} 2>&1`], {
+    execFile('bash', ['-lc', `${cmd} 2>&1`], {
       encoding: 'utf8',
       maxBuffer: 64 * 1024,
-    }, (err, stdout) => {
-      resolve(err ? '' : stdout);
+      timeout: parseShellTimeout(timeout),
+    }, (err, stdout, stderr) => {
+      resolve((stdout || stderr || '').trim());
     });
   });
 }
@@ -38,7 +51,6 @@ function execHermes(args, timeout = 30000) {
 }
 
 const PORT = Number(process.env.PORT || 10272);
-const CONTROL_PASSWORD = process.env.HERMES_CONTROL_PASSWORD;
 const CONTROL_SECRET = process.env.HERMES_CONTROL_SECRET;
 const AUTH_COOKIE = 'hermes_control_auth';
 const PROJECT_ROOT = __dirname;
@@ -90,8 +102,8 @@ const IGNORED_DIRS = new Set([
   'node_modules', '.git', 'cache', 'document_cache', 'audio_cache', 'checkpoints', 'logs', 'tmp', '.next', '.turbo', '.cache',
 ]);
 
-if (!CONTROL_PASSWORD || !CONTROL_SECRET) {
-  throw new Error('Missing HERMES_CONTROL_PASSWORD or HERMES_CONTROL_SECRET environment variables');
+if (!CONTROL_SECRET) {
+  throw new Error('Missing HERMES_CONTROL_SECRET environment variable');
 }
 
 const app = express();
@@ -1297,9 +1309,13 @@ app.post('/api/notifications/clear', requireAuth, (req, res) => {
 // ============================================
 app.get('/api/system/health', requireAuth, async (req, res) => {
   try {
-    const [cpu, ram, disk, version, agents, sessions] = await Promise.all([
-      shell("top -bn1 | grep 'Cpu(s)' | awk '{print $2}'"),
-      shell("free -m | awk '/Mem:/ {printf \"%d/%dMB (%.0f%%)\", $3, $2, $3/$2*100}'"),
+    const memTotalMb = Math.round(os.totalmem() / 1024 / 1024);
+    const memUsedMb = Math.round((os.totalmem() - os.freemem()) / 1024 / 1024);
+    const cpuCores = Math.max(1, os.cpus().length || 1);
+    const load1 = os.loadavg()[0] || 0;
+    const cpuPct = Math.min(100, Math.max(0, Math.round((load1 / cpuCores) * 100)));
+
+    const [disk, version, agents, sessions] = await Promise.all([
       shell("df -h / | awk 'NR==2 {print $3\"/\"$2\" (\"$5\")\"}'"),
       shell("hermes version 2>&1 | head -1"),
       shell("hermes profile list 2>&1 | wc -l"),
@@ -1313,8 +1329,8 @@ app.get('/api/system/health', requireAuth, async (req, res) => {
     const uptime = upDays > 0 ? `${upDays}d ${upHrs}h ${upMins}m` : upHrs > 0 ? `${upHrs}h ${upMins}m` : `${upMins}m`;
     res.json({
       ok: true,
-      cpu: cpu.trim() || 'N/A',
-      ram: ram.trim() || 'N/A',
+      cpu: `${cpuPct}% (${load1.toFixed(2)} load / ${cpuCores} cores)`,
+      ram: `${memUsedMb}/${memTotalMb}MB (${Math.round((memUsedMb / memTotalMb) * 100)}%)`,
       disk: disk.trim() || 'N/A',
       uptime,
       hermes_version: version.trim() || 'N/A',

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,7 @@
 import { defineConfig } from 'vite';
-import { resolve } from 'path';
+
+const backendUrl = process.env.HCI_BACKEND_URL || 'http://localhost:10272';
+const backendWsUrl = backendUrl.replace(/^http/, 'ws');
 
 export default defineConfig({
   root: 'src',
@@ -10,9 +12,9 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/api': 'http://localhost:10274',
+      '/api': backendUrl,
       '/ws': {
-        target: 'ws://localhost:10274',
+        target: backendWsUrl,
         ws: true,
       },
     },


### PR DESCRIPTION
## Summary
- align docs and helper scripts with the current first-run multi-user auth flow
- fix macOS runtime issues in shell execution and system health reporting
- correct the Vite dev proxy backend target and password reset tooling

## Test Plan
- bash -n install.sh
- bash -n reset-password.sh
- node --check scripts/reset-password.js
- npm run build
- npm test
- verify the launch agent owns port 10272 locally
