### PR TITLE
fix: make runtime metrics and dev proxy macOS-safe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,24 +8,16 @@
 
 # Required
 
-# Password for the login screen. Use a long random string in production.
-# Generate one with: openssl rand -hex 32
-HERMES_CONTROL_PASSWORD=
-
 # HMAC secret for signing auth tokens and internal request verification.
 # Generate one with: openssl rand -hex 32
 HERMES_CONTROL_SECRET=
 
 # Optional
 
-# HTTPS support (optional — browsers may force HTTPS on IP addresses).
-# Generate self-signed certs with:
-#   openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -subj "/CN=<your-ip-or-hostname>"
-# Note: SSL_CERT_FILE is a macOS/system reserved variable — use the HCI_ prefix.
-# HCI_SSL_CERT_FILE=/path/to/cert.pem
-# HCI_SSL_KEY_FILE=/path/to/key.pem
-#
-# Port to listen on. Default: 10272
+# Legacy bootstrap password from the pre-user-store auth model.
+# The current first-run multi-user flow does not require this.
+# HERMES_CONTROL_PASSWORD=
+
 # HTTPS support (optional — browsers may force HTTPS on IP addresses).
 # Generate self-signed certs with:
 #   openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -subj "/CN=<your-ip-or-hostname>"

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ A self-hosted web dashboard for the [Hermes AI agent](https://github.com/NousRes
 
 ### 🔐 Authentication
 
-- Single password login (configurable via `HERMES_CONTROL_PASSWORD`)
-- bcrypt password hashing (cost factor 10)
+- First-run admin setup when no users exist
+- Per-user bcrypt password hashing in the local user store
 - CSRF tokens on all mutating requests
 - Conditional Secure cookie flag (auto-detects HTTPS)
 - Rate limiting: 5 failed logins per 15 minutes per IP
@@ -334,9 +334,9 @@ npm install
 
 # 3. Configure
 cp .env.example .env
-# Edit .env and set:
-#   HERMES_CONTROL_PASSWORD=your-secure-password
-#   HERMES_CONTROL_SECRET=$(openssl rand -hex 32)
+# Edit .env:
+#   HERMES_CONTROL_SECRET=your-random-secret
+# Then start the app and create the first admin in the UI
 
 # 4. Build frontend
 npm run build
@@ -385,8 +385,8 @@ sudo systemctl start hermes-control
 
 | Variable | Required | Description |
 |---|---|---|
-| `HERMES_CONTROL_PASSWORD` | Yes | Login password |
 | `HERMES_CONTROL_SECRET` | Yes | CSRF + internal auth secret |
+| `HERMES_CONTROL_PASSWORD` | No | Legacy single-password auth variable |
 | `PORT` | No | Server port (default: 10272) |
 | `HERMES_CONTROL_HOME` | No | Hermes home dir (default: ~/.hermes) |
 | `HERMES_CONTROL_ROOTS` | No | File explorer roots (JSON array) |
@@ -394,28 +394,15 @@ sudo systemctl start hermes-control
 
 ---
 
-## Reset Password Without Dashboard Access
+## Access Recovery
 
-If you can't log in to the dashboard, reset the password via CLI:
+If you can't log in to the dashboard:
 
-**Option 1 — Edit .env directly**
-```bash
-# SSH into your server
-nano ~/.hermes/.env
-# Change HERMES_CONTROL_PASSWORD=your-new-password
+- verify `HERMES_CONTROL_SECRET` is still set correctly in `.env`
+- check whether any users still exist in `~/.hermes/hci-users.json`
+- if the user store is empty, restart the app and use the first-run setup screen to create a new admin
 
-# Restart
-sudo systemctl restart hermes-control
-# or: pkill node; npm start &
-```
-
-**Option 2 — Generate bcrypt hash via Node.js**
-```bash
-node -e "const bcrypt=require('bcrypt'); bcrypt.hash(require('crypto').randomBytes(24).toString('hex'), 10).then(h=>console.log('HERMES_CONTROL_PASSWORD='+h))"
-# Copy the output to .env, then restart
-```
-
-**Key point:** `.env` is the source of truth. Dashboard access = server access. If you lose access to both, you must have server/SSH access to reset.
+**Key point:** the current auth flow is user-store based, not `.env`-password based.
 
 ---
 
@@ -443,12 +430,15 @@ auth.js                 # Multi-user auth + RBAC (bcrypt, sessions, permissions)
 ## Development
 
 ```bash
-# Edit source in src/
-npx vite build
+# Terminal 1: backend API on the default app port
+npm start
 
-# Restart (never in foreground — use detached)
-kill $(lsof -t -i:10272) 2>/dev/null
-nohup node server.js &>/dev/null & disown
+# Terminal 2: frontend dev server
+npx vite
+
+# Production build
+npm run build
+npm start
 ```
 
 ---

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@ Base URL: `http://localhost:10272` (or your domain if behind a reverse-proxy)
 
 All endpoints marked **Auth required** require a valid session cookie (`hermes...auth`).
 
-Login first via `POST /api/auth/login` to receive the cookie.
+Use `GET /api/auth/status` first. If it reports `first_run: true`, create the first admin with `POST /api/auth/setup`. Otherwise log in via `POST /api/auth/login`.
 
 Internal endpoints (marked **Internal**) require the `x-hermes-control-secret` header matching `HERMES_CONTROL_SECRET` instead of a cookie.
 
@@ -37,13 +37,37 @@ Returns a basic health check.
 
 **Auth required:** No
 
-Returns the current authentication state.
+Returns whether the app is in first-run mode and how many users exist.
 
 ```json
 {
-  "authenticated": false,
-  "passwordRequired": true,
-  "identity": "root@hermes"
+  "ok": true,
+  "first_run": true,
+  "user_count": 0
+}
+```
+
+---
+
+### `POST /api/auth/setup`
+
+**Auth required:** No
+
+**Rate limited:** 5 attempts per 15 minutes per IP.
+
+Creates the first admin account when no users exist.
+
+**Request body:**
+```json
+{ "username": "admin", "password": "your-password" }
+```
+
+**Success response (200):**
+```json
+{
+  "ok": true,
+  "user": { "username": "admin", "role": "admin" },
+  "csrfToken": "..."
 }
 ```
 
@@ -57,18 +81,27 @@ Returns the current authentication state.
 
 **Request body:**
 ```json
-{ "password": "***" }
+{ "username": "admin", "password": "your-password" }
 ```
 
 **Success response (200):**
 ```json
-{ "ok": true }
+{
+  "ok": true,
+  "user": { "username": "admin", "role": "admin", "permissions": ["..."] },
+  "csrfToken": "..."
+}
 ```
 Sets the `hermes...auth` cookie.
 
 **Failure response (401):**
 ```json
-{ "ok": false, "error": "bad password" }
+{ "ok": false, "error": "Invalid username or password" }
+```
+
+**First-run response (400):**
+```json
+{ "ok": false, "error": "first_run", "message": "No users exist. Please create an admin account." }
 ```
 
 **Rate limited response (429):**

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -5,7 +5,7 @@ Hermes Control Interface can be configured in two complementary ways:
 1. **`hci.config.yaml`** — declarative, version-controllable defaults (checked into git)
 2. **Environment variables** — runtime overrides (never stored in plaintext)
 
-Environment variables always take precedence over the YAML file, so secrets (password, secret, API keys) can be kept out of the config file and supplied via env.
+Environment variables always take precedence over the YAML file, so secrets (secret, API keys) can be kept out of the config file and supplied via env.
 
 ---
 
@@ -15,7 +15,7 @@ Environment variables always take precedence over the YAML file, so secrets (pas
 
 ```bash
 cp .env.example .env
-# Fill in HERMES_CONTROL_PASSWORD and HERMES_CONTROL_SECRET
+# Fill in HERMES_CONTROL_SECRET
 npm start
 ```
 
@@ -24,7 +24,7 @@ npm start
 ```bash
 # Create hci.config.yaml next to server.js
 cp hci.config.yaml.example hci.config.yaml
-# Fill in password and secret (all other keys are optional)
+# Fill in secret if you use YAML defaults (all other keys are optional)
 npm start
 ```
 
@@ -44,7 +44,7 @@ Create `hci.config.yaml` in the repo root (next to `server.js`). All keys are op
 ```yaml
 # ── Required ────────────────────────────────────────────────────────────
 
-password: "your-long-random-password"          # REQUIRED
+# password is legacy and no longer required for the current first-run auth flow
 secret:   "your-hmac-secret"                  # REQUIRED
 
 # ── Server ──────────────────────────────────────────────────────────────
@@ -106,8 +106,8 @@ session:
 
 | Variable | Default | Description |
 |---|---|---|
-| `HERMES_CONTROL_PASSWORD` | — | **Required.** Login password |
 | `HERMES_CONTROL_SECRET` | — | **Required.** HMAC signing secret |
+| `HERMES_CONTROL_PASSWORD` | — | Legacy single-password auth variable |
 | `PORT` | `10272` | Server listen port |
 | `HERMES_CONTROL_HOME` | `~/.hermes` | Hermes root directory |
 | `HERMES_PROJECTS_ROOT` | auto | Projects explorer root |
@@ -146,10 +146,10 @@ When the YAML file has nested keys, they map to env vars using `SECTION_KEY` con
 
 ## Verifying Your Config
 
-The server validates required variables on startup. If `password` or `secret` is missing from both `hci.config.yaml` and the environment, it exits immediately with:
+The server validates required variables on startup. If `HERMES_CONTROL_SECRET` is missing, it exits immediately with:
 
 ```
-Error: Missing HERMES_CONTROL_PASSWORD (set env var or password in hci.config.yaml)
+Error: Missing HERMES_CONTROL_SECRET environment variable
 ```
 
 To check if your config is loading correctly, start the server and look for:
@@ -177,13 +177,11 @@ rate_limit:
 
 **`.env`** (NOT committed — secrets only):
 ```bash
-HERMES_CONTROL_PASSWORD=$(openssl rand -hex 32)
 HERMES_CONTROL_SECRET=$(openssl rand -hex 32)
 ```
 
 **systemd `Environment=` directives** (alternative to `.env`):
 ```ini
-Environment=HERMES_CONTROL_PASSWORD=<generated>
 Environment=HERMES_CONTROL_SECRET=<generated>
 ```
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -27,7 +27,6 @@ The dashboard supports two config patterns. Choose the one that fits your deploy
 ```bash
 cp .env.example .env
 # Edit .env and set:
-#   HERMES_CONTROL_PASSWORD=$(openssl rand -hex 32)
 #   HERMES_CONTROL_SECRET=$(openssl rand -hex 32)
 ```
 
@@ -35,12 +34,11 @@ cp .env.example .env
 
 ```bash
 cp hci.config.yaml.example hci.config.yaml
-# Edit hci.config.yaml (password and secret are required):
-#   password: "<generate with: openssl rand -hex 32>"
-#   secret:   "<generate with: openssl rand -hex 32>"
+# Edit hci.config.yaml if you need non-secret defaults
+# Keep secrets in .env or Environment= lines
 ```
 
-> **Why YAML?** `hci.config.yaml` can be committed to version control and shared across machines, while secrets (password, secret) are still supplied via environment variables (`.env` or systemd `Environment=` lines) so they never appear in plaintext in the repo.
+> **Why YAML?** `hci.config.yaml` can be committed to version control and shared across machines, while secrets are still supplied via environment variables (`.env` or systemd `Environment=` lines) so they never appear in plaintext in the repo.
 
 ### Verify startup
 
@@ -148,7 +146,6 @@ ExecStart=/usr/bin/node server.js
 Restart=always
 RestartSec=10
 Environment=NODE_ENV=production
-# Environment=HERMES_CONTROL_PASSWORD=<generate with: openssl rand -hex 32>
 # Environment=HERMES_CONTROL_SECRET=<generate with: openssl rand -hex 32>
 
 # Run as non-root user (recommended for production)
@@ -171,7 +168,7 @@ sudo systemctl status hermes-control
 
 ## Step 5 — Verify
 
-Open `https://hermes.example.com` in your browser. You should see the login screen. Log in with your configured password.
+Open `https://hermes.example.com` in your browser. On a clean install, create the first admin account. After that, log in with the account you created.
 
 ---
 
@@ -239,8 +236,8 @@ See [CONFIG.md](./CONFIG.md) for the full configuration schema.
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `HERMES_CONTROL_PASSWORD` | ✅ | — | Login password (min 32 chars in production) |
 | `HERMES_CONTROL_SECRET` | ✅ | — | HMAC secret for auth tokens |
+| `HERMES_CONTROL_PASSWORD` | — | — | Legacy single-password auth variable |
 | `PORT` | — | `10272` | Server listen port |
 | `GATEWAY_API_KEY` | — | auto | Gateway API auth key (auto-discovers from hermes config.yaml) |
 | `HCI_CORS_ORIGINS` | — | auto-detect → localhost | Comma-separated CORS origins for production |

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -20,11 +20,12 @@ npm install
 
 Edit `.env` and set:
 
-- `HERMES_CONTROL_PASSWORD`
 - `HERMES_CONTROL_SECRET`
 - `PORT` if you want a different port
 - `HERMES_CONTROL_HOME` if your Hermes state lives somewhere else
 - `HERMES_PROJECTS_ROOT` if your repos live outside the parent directory of this repo
+
+`HERMES_CONTROL_PASSWORD` is legacy and not required for the current first-run multi-user auth flow.
 
 ## Run
 
@@ -34,17 +35,19 @@ npm start
 
 Open `http://127.0.0.1:10272` in your browser.
 
+On a clean install, the UI will prompt you to create the first admin account.
+
 If you want to expose the app beyond localhost, put it behind a reverse proxy and TLS. Do not publish the raw port without a plan.
 
 ## Environment Variables
 
-After copying `.env.example` to `.env`, the **required** variables are:
+After copying `.env.example` to `.env`, the **required** variable is:
 
-- `HERMES_CONTROL_PASSWORD` — Login password (generate with `openssl rand -hex 32`)
 - `HERMES_CONTROL_SECRET` — HMAC secret for auth tokens (generate with `openssl rand -hex 32`)
 
 **Optional** (have sensible defaults):
 
+- `HERMES_CONTROL_PASSWORD` — legacy single-password auth variable; not required for the current flow
 - `GATEWAY_API_KEY` — Gateway API auth key. Default: reads from `~/.hermes/config.yaml`. Only set if your key differs.
 - `HCI_CORS_ORIGINS` — Comma-separated CORS origins for production. Default: auto-detects from request, falls back to localhost. Set for production: `HCI_CORS_ORIGINS=https://your-domain.com`
 - `PORT` — Server listen port. Default: `10272`

--- a/docs/PASSWORD.md
+++ b/docs/PASSWORD.md
@@ -2,68 +2,35 @@
 
 ## How It Works
 
-HCI stores the dashboard password in `.env` as `HERMES_CONTROL_PASSWORD`.
+HCI uses a local user store at `~/.hermes/hci-users.json`.
 
-The password can be stored in two formats:
-
-### Bcrypt Hashed (Recommended)
-```
-HERMES_CONTROL_PASSWORD=$2b$10...y...
-```
-- Starts with `$2b$` or `$2a$`
-- Compared using `bcrypt.compareSync()` — timing-safe, irreversible
-- If `.env` leaks, attacker cannot recover the password
-
-### Plaintext
-```
-HERMES_CONTROL_PASSWORD=mysecr...d123
-```
-- Compared using `crypto.timingSafeEqual()` — timing-safe but reversible
-- If `.env` leaks, attacker can read the password directly
-
-The server auto-detects which format is used on login.
+- On first run, the UI prompts you to create the first admin account.
+- Passwords are stored as bcrypt hashes in the user store.
+- `HERMES_CONTROL_SECRET` in `.env` is still required for signing auth tokens and internal request verification.
+- `HERMES_CONTROL_PASSWORD` is a legacy env var from the older single-password auth model and is no longer required for the current flow.
 
 ---
 
-## Generate a Secure Password
+## First Run
 
-Generate a bcrypt-hashed password with Node.js:
-```bash
-node -e "const bcrypt=require('bcrypt'); bcrypt.hash(require('crypto').randomBytes(24).toString('hex'), 10).then(h=>console.log('HERMES_CONTROL_PASSWORD='+h))"
-```
-
----
-
-## Reset Password
-
-1. Edit `.env` and set a new value for `HERMES_CONTROL_PASSWORD`
-2. If using bcrypt format, regenerate the hash using the command above
-3. Restart the server:
-```bash
-# Direct
-npm start
-
-# Systemd
-sudo systemctl restart hermes-control
-```
+1. Copy `.env.example` to `.env`
+2. Set `HERMES_CONTROL_SECRET`
+3. Start the server
+4. Open the UI and create the first admin account
 
 ---
 
-## Check Current Password Format
+## Reset a User Password
 
-```bash
-grep HERMES_CONTROL_PASSWORD .env
-```
+Use the dashboard's user-management flow, or edit the user store with a trusted local maintenance path if you have to recover access.
 
-- Starts with `$2b$` or `$2a$` → bcrypt hashed (secure)
-- Anything else → plaintext (edit `.env` to set a new bcrypt-hashed value)
+If no users exist, the app returns to first-run setup and lets you create a new admin account.
 
 ---
 
 ## Security Notes
 
-- The bcrypt hash is **one-way** — you cannot recover the plaintext from it
-- If you forget your password, you MUST reset it (there's no recovery)
-- Keep your `.env` file permissions at `600` (`chmod 600 .env`)
-- Never commit `.env` to git (it's in `.gitignore` by default)
-- `HERMES_CONTROL_SECRET` is separate — it's used for auth token signing, not password comparison
+- Password hashes are one-way bcrypt hashes
+- Keep `.env` permissions tight (`chmod 600 .env`)
+- Never commit `.env` to git
+- Rotating `HERMES_CONTROL_SECRET` invalidates existing sessions

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -4,13 +4,13 @@
 
 ## Server won't start
 
-### `Error: Missing HERMES_CONTROL_PASSWORD or HERMES_CONTROL_SECRET environment variables`
+### `Error: Missing HERMES_CONTROL_SECRET environment variable`
 
-The `.env` file is missing or those variables are empty.
+The `.env` file is missing or `HERMES_CONTROL_SECRET` is empty.
 
 ```bash
 cp .env.example .env
-# Edit .env and fill in both values
+# Edit .env and fill in HERMES_CONTROL_SECRET
 npm start
 ```
 
@@ -52,13 +52,16 @@ node -v  # should be v20.x.x or higher
 
 ### Login form returns 401
 
-Wrong password. Check the value in `.env`:
+Wrong username or password. In the current auth flow, credentials live in the local user store, not `.env`.
+
+Checks:
 
 ```bash
-grep HERMES_CONTROL_PASSWORD .env
+curl http://localhost:10272/api/auth/status
 ```
 
-There is no way to recover a lost password except by setting a new one in `.env`.
+- If `first_run` is `true`, create the first admin account in the UI.
+- If users already exist, log in with a valid username/password from the local user store.
 
 ### Login appears to succeed but immediately asks for password again
 
@@ -199,4 +202,5 @@ sudo journalctl -u hermes-control -n 50
 Common issues:
 - Wrong `WorkingDirectory` in the service file
 - Missing `.env` — systemd doesn't load it automatically. Either set `Environment=` vars in the service file, or use `EnvironmentFile=/path/to/.env`
+- On macOS, Linux-only commands like `top -bn1` and `free -m` will break health panels unless you run a patched build
 - `node` not on PATH — use the absolute path in `ExecStart`, e.g. `/usr/bin/node`

--- a/lib/hci-config.js
+++ b/lib/hci-config.js
@@ -15,7 +15,7 @@
  * YAML schema (all keys are optional unless noted):
  *
  *   port: 10272                       # server listen port
- *   password: "..."                   # REQUIRED — login password
+ *   password: "..."                   # OPTIONAL legacy single-password auth value
  *   secret: "..."                     # REQUIRED — HMAC signing secret
  *   hermes_home: "~/.hermes"          # Hermes root (state dir, avatar, layout)
  *   projects_root: "~/projects"       # projects explorer root
@@ -144,13 +144,12 @@ function buildConfig() {
   );
 
   // ── Required values ─────────────────────────────────────────────────────
-  // Env wins; fall back to YAML; error if neither.
+  // Env wins; fall back to YAML. Secret is required; password stays optional
+  // for legacy single-password installs.
   const password = process.env.HERMES_CONTROL_PASSWORD
     || yamlMap.HERMES_CONTROL_PASSWORD
-    || yamlMap.PASSWORD;
-  if (!password) {
-    throw new Error('Missing HERMES_CONTROL_PASSWORD (set env var or password in hci.config.yaml)');
-  }
+    || yamlMap.PASSWORD
+    || null;
 
   const secret = process.env.HERMES_CONTROL_SECRET
     || yamlMap.HERMES_CONTROL_SECRET

--- a/server.js
+++ b/server.js
@@ -157,8 +157,8 @@ const IGNORED_DIRS = new Set([
   'node_modules', '.git', 'cache', 'document_cache', 'audio_cache', 'checkpoints', 'logs', 'tmp', '.next', '.turbo', '.cache',
 ]);
 
-if (!CONTROL_PASSWORD || !CONTROL_SECRET) {
-  throw new Error('Missing HERMES_CONTROL_PASSWORD or HERMES_CONTROL_SECRET environment variables');
+if (!CONTROL_SECRET) {
+  throw new Error('Missing HERMES_CONTROL_SECRET environment variable');
 }
 
 const app = express();
@@ -1678,7 +1678,7 @@ async function buildDashboardState(authed = false) {
   return {
     title: 'Hermes Control Interface',
     now: new Date().toISOString(),
-    passwordRequired: true,
+    firstRun: isFirstRun(),
     authed,
     agent: buildSpriteState(),
     system: getSystem(),
@@ -1715,7 +1715,7 @@ async function buildDashboardState(authed = false) {
 
 app.get('/api/session', (req, res) => {
   const authed = isAuthed(req);
-  const response = { authenticated: authed, passwordRequired: true, identity: HCI_IDENTITY };
+  const response = { authenticated: authed, firstRun: isFirstRun(), identity: HCI_IDENTITY };
   if (authed) {
     const cookies = parseCookies(req);
     response.csrfToken = deriveCsrfToken(cookies[AUTH_COOKIE]);
@@ -3347,7 +3347,7 @@ const KEY_METADATA = {
   SLACK_BOT_TOKEN:         { cat: 'Messaging Platforms', desc: 'Slack bot token (xoxb)',      url: 'https://api.slack.com/apps', adv: false },
   WHATSAPP_SESSION_PATH:   { cat: 'Messaging Platforms', desc: 'WhatsApp session file path', url: '',  adv: false },
   // Agent Settings
-  HERMES_CONTROL_PASSWORD:  { cat: 'Agent Settings',   desc: 'HCI control password',         url: '',  adv: false },
+  HERMES_CONTROL_PASSWORD:  { cat: 'Agent Settings',   desc: 'Legacy HCI control password',  url: '',  adv: false },
   HERMES_CONTROL_SECRET:   { cat: 'Agent Settings',   desc: 'HCI control secret',           url: '',  adv: true },
   API_SERVER_ENABLED:      { cat: 'Agent Settings',   desc: 'Enable API server',             url: '',  adv: false },
   API_SERVER_PORT:         { cat: 'Agent Settings',   desc: 'API server port',               url: '',  adv: true },

--- a/server.js
+++ b/server.js
@@ -82,11 +82,24 @@ function calculateCost(model, inputTokens, outputTokens, cacheReadTokens = 0, bi
 }
 
 // Async shell execution utility (non-blocking)
+function parseShellTimeout(timeout = '8s') {
+  if (typeof timeout === 'number' && Number.isFinite(timeout)) return timeout;
+  const raw = String(timeout).trim();
+  const match = raw.match(/^(\d+)(ms|s|m)?$/i);
+  if (!match) return 8000;
+  const value = Number(match[1]);
+  const unit = (match[2] || 's').toLowerCase();
+  if (unit === 'ms') return value;
+  if (unit === 'm') return value * 60 * 1000;
+  return value * 1000;
+}
+
 function shell(cmd, timeout = '8s') {
   return new Promise((resolve) => {
-    execFile('bash', ['-lc', `timeout ${timeout} ${cmd} 2>&1`], {
+    execFile('bash', ['-lc', `${cmd} 2>&1`], {
       encoding: 'utf8',
       maxBuffer: 64 * 1024,
+      timeout: parseShellTimeout(timeout),
     }, (err, stdout) => {
       resolve(err ? '' : stdout);
     });
@@ -1994,19 +2007,34 @@ app.post('/api/notifications/clear', requireAuth, requireCsrf, (req, res) => {
   res.json({ ok: true });
 });
 
+function formatCpuUsage() {
+  const load = os.loadavg()[0] || 0;
+  const cores = Math.max(os.cpus().length || 1, 1);
+  return `${Math.min(100, (load / cores) * 100).toFixed(1)}%`;
+}
+
+function formatMemoryUsage(precision = 0) {
+  const total = os.totalmem();
+  const used = total - os.freemem();
+  const usedMb = Math.round(used / 1024 / 1024);
+  const totalMb = Math.round(total / 1024 / 1024);
+  const pct = total > 0 ? (used / total) * 100 : 0;
+  return `${usedMb}/${totalMb}MB (${pct.toFixed(precision)}%)`;
+}
+
 // ============================================
 // System Health API
 // ============================================
 app.get('/api/system/health', requireAuth, async (req, res) => {
   try {
-    const [cpu, ram, disk, version, agents, sessions] = await Promise.all([
-      shell("top -bn1 | grep 'Cpu(s)' | awk '{print $2}'"),
-      shell("free -m | awk '/Mem:/ {printf \"%d/%dMB (%.0f%%)\", $3, $2, $3/$2*100}'"),
+    const [disk, version, agents, sessions] = await Promise.all([
       shell("df -h / | awk 'NR==2 {print $3\"/\"$2\" (\"$5\")\"}'"),
       shell("hermes version 2>&1 | head -1"),
       shell("hermes profile list 2>&1 | wc -l"),
       shell("hermes sessions list --limit 1000 2>&1 | wc -l"),
     ]);
+    const cpu = formatCpuUsage();
+    const ram = formatMemoryUsage(0);
     // Format uptime from process.uptime()
     const upSec = process.uptime();
     const upDays = Math.floor(upSec / 86400);
@@ -2033,28 +2061,22 @@ app.get('/api/system/health', requireAuth, async (req, res) => {
 // System Monitoring — detailed metrics
 app.get('/api/monitoring', requireAuth, async (req, res) => {
   try {
-    const [cpu, mem, disk, loadAvg, netio, processes, uptime, version] = await Promise.all([
-      shell("top -bn1 | grep 'Cpu(s)' | awk '{print $2}'"),
-      shell("free -m | awk '/Mem:/ {printf \"%d/%dMB (%.1f%%)\", $3, $2, $3/$2*100}'"),
+    const [disk, processes, uptime, version] = await Promise.all([
       shell("df -h / | awk 'NR==2 {print $3\"/\"$2\" (\"$5\")\"}'"),
-      shell("cat /proc/loadavg | awk '{print $1\", \"$2\", \"$3}'"),
-      shell("cat /proc/net/dev | awk 'NR==3 {print $1, $9}'"),
       shell("ps aux --no-headers | wc -l"),
       shell("uptime | awk -F'up ' '{split($2,a,\" user\");print a[1]\", \"$3}'"),
       shell("hermes version 2>&1 | head -1"),
     ]);
 
-    // Parse network interface (skip loopback)
-    const netParts = (netio || 'lo 0').trim().split(/\s+/);
-    const netInterface = netParts[0] || 'eth0';
-    const netBytes = netParts[1] || '0';
-    const netPackets = netParts[2] || '0';
-
-    // CPU percentage (already in format like "12.5%")
-    const cpuPct = (cpu.trim() || 'N/A').replace(/,/g, '');
+    const cpuPct = formatCpuUsage();
+    const memFmt = formatMemoryUsage(1);
+    const loadAvg = os.loadavg().slice(0, 3).map((n) => n.toFixed(2)).join(', ');
+    const netInterface = 'n/a';
+    const netBytes = '0';
+    const netPackets = '0';
 
     // Memory usage
-    const memInfo = mem.trim() || 'N/A';
+    const memInfo = memFmt;
 
     // Disk usage
     const diskInfo = disk.trim() || 'N/A';

--- a/test/session-list.test.js
+++ b/test/session-list.test.js
@@ -17,6 +17,7 @@ Parent Session                   hello world                              2h ago
       title: 'Parent Session',
       preview: 'hello world',
       lastActive: '2h ago',
+      source: null,
     },
   ]);
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
 
+const backendUrl = process.env.HCI_BACKEND_URL || 'http://localhost:10272';
+const backendWsUrl = backendUrl.replace(/^http/, 'ws');
+
 export default defineConfig({
   root: 'src',
   build: {
@@ -10,9 +13,9 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/api': 'http://localhost:10274',
+      '/api': backendUrl,
       '/ws': {
-        target: 'ws://localhost:10274',
+        target: backendWsUrl,
         ws: true,
       },
     },


### PR DESCRIPTION
## Summary
- make shell command timeouts work without relying on GNU `timeout`
- replace Linux-only CPU/RAM monitoring commands with macOS-safe Node/os metrics
- make Vite dev proxy target configurable via `HCI_BACKEND_URL`

## Test Plan
- [x] `node --check server.js`
- [x] `npm test`
- [ ] `npm run build` *(blocked in this clean worktree because `node_modules`/`vite` are not installed locally)*
