### PR TITLE
Fix profile list parsing for long Hermes profile names

### DIFF
--- a/server.js
+++ b/server.js
@@ -2273,13 +2273,21 @@ function parseHermesProfileList(raw) {
   for (const line of dataLines) {
     const active = line.includes('◆');
     const cleaned = line.replace(/[◆]+$/, '').replace(/\s*◆\s*/, '').trimEnd();
-    const parts = cleaned.split(/\s{2,}/).map((p) => p.trim()).filter(Boolean);
+    const parts = cleaned.split(/\s+/).map((p) => p.trim()).filter(Boolean);
     if (parts.length < 3) continue;
+    const gatewayIndex = parts.findIndex((p) => /^(running|stopped)$/i.test(p));
+    if (gatewayIndex < 2) continue;
+    const name = parts.slice(0, gatewayIndex - 1).join(' ');
+    const model = parts[gatewayIndex - 1];
+    const gateway = parts[gatewayIndex].toLowerCase();
+    const alias = parts[gatewayIndex + 1] && parts[gatewayIndex + 1] !== '—'
+      ? parts.slice(gatewayIndex + 1).join(' ')
+      : null;
     profiles.push({
-      name: parts[0] || '',
-      model: parts[1] || '—',
-      gateway: (parts[2] || '').toLowerCase(),
-      alias: parts[3] && parts[3] !== '—' ? parts[3] : null,
+      name: name || '',
+      model: model || '—',
+      gateway,
+      alias,
       active,
     });
   }


### PR DESCRIPTION
## Summary

This fixes profile parsing when `hermes profile list` contains a long profile name that collapses the spacing between the `Profile` and `Model` columns.

In that case, HCI can misread the profile name and shift the remaining columns.

## Example

Given output like:

```text
product-compass-consulting gpt-5.5                      stopped      —
```

The current parser can interpret:

```text
name:  product-compass-consulting gpt-5.5
model: stopped
```

Instead, it should parse:

```text
name:    product-compass-consulting
model:   gpt-5.5
gateway: stopped
alias:   null
```

## Change

Instead of splitting profile rows only on two-or-more spaces, this parses from the gateway status token:

- find `running` or `stopped`
- treat the token before it as the model
- treat tokens before the model as the profile name
- treat tokens after the gateway status as the alias, unless it is `—`

This keeps existing short-profile behavior while handling long valid profile names more reliably.

## Verification

Tested with profiles including:

- `default`
- `paco-studio`
- `minimax-studio`
- `product-compass-consulting`

The long profile now renders correctly as:

```json
{
  "name": "product-compass-consulting",
  "model": "gpt-5.5",
  "gateway": "stopped",
  "alias": null
}
```
