### PR TITLE
feat: add Mira workflow console read-only MVP

### DIFF
--- a/lib/workflow-worker-runner.js
+++ b/lib/workflow-worker-runner.js
@@ -1,0 +1,68 @@
+const { spawnSync } = require('node:child_process');
+const { upsertWorkerStatus } = require('./workflow-worker-status');
+
+function currentTimestamp(now) {
+  return typeof now === 'function' ? now() : (now || new Date().toISOString());
+}
+
+function statusForExit(result = {}) {
+  if (result.signal) return 'stopped';
+  if (result.status === 0) return 'idle';
+  if (result.status === 130 || result.status === 143) return 'stopped';
+  return 'error';
+}
+
+function noteForExit(result = {}) {
+  if (result.signal) return `terminated by ${result.signal}`;
+  return `exited ${Number.isInteger(result.status) ? result.status : 1}`;
+}
+
+function writeWorkerStatus(options, status, note) {
+  const snapshot = upsertWorkerStatus({
+    repoDir: options.repoDir,
+    file: options.file,
+    id: options.id,
+    label: options.label,
+    provider: options.provider,
+    sessionId: options.sessionId,
+    status,
+    note,
+    updatedAt: currentTimestamp(options.now),
+  });
+  if (typeof options.onStatus === 'function') options.onStatus(snapshot);
+  return snapshot;
+}
+
+function runWorkerCommand(options) {
+  if (!options || typeof options !== 'object') throw new Error('options are required');
+  const command = String(options.command || '').trim();
+  if (!command) throw new Error('command is required');
+
+  writeWorkerStatus(options, 'generating', options.startNote || 'started');
+
+  const runner = options.spawnSync || spawnSync;
+  const result = runner(command, options.args || [], {
+    cwd: options.cwd || options.repoDir || process.cwd(),
+    env: options.env || process.env,
+    stdio: options.stdio || 'inherit',
+    shell: Boolean(options.shell),
+  });
+
+  if (result.error) {
+    writeWorkerStatus(options, 'error', result.error.message || 'failed to launch');
+    return { exitCode: 1, signal: result.signal || null, error: result.error };
+  }
+
+  const finalStatus = statusForExit(result);
+  writeWorkerStatus(options, finalStatus, noteForExit(result));
+
+  return {
+    exitCode: Number.isInteger(result.status) ? result.status : (result.signal ? 143 : 1),
+    signal: result.signal || null,
+  };
+}
+
+module.exports = {
+  runWorkerCommand,
+  statusForExit,
+};

--- a/lib/workflow-worker-status.js
+++ b/lib/workflow-worker-status.js
@@ -1,0 +1,93 @@
+const fs = require('fs');
+const path = require('path');
+const { normalizeWorkerStatus } = require('./workflows');
+
+function normalizeString(value) {
+  return String(value || '').trim();
+}
+
+function resolveWorkerStatusPath(repoDir, file) {
+  const resolvedRepoDir = path.resolve(repoDir || process.cwd());
+  const rawFile = normalizeString(file);
+  if (!rawFile || path.isAbsolute(rawFile)) {
+    throw new Error('worker status file must be a repo-local relative path');
+  }
+  const resolvedPath = path.resolve(resolvedRepoDir, rawFile);
+  const relative = path.relative(resolvedRepoDir, resolvedPath);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error('worker status file resolves outside repo');
+  }
+  return resolvedPath;
+}
+
+function readSnapshot(snapshotPath) {
+  try {
+    const raw = fs.readFileSync(snapshotPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return { workers: parsed };
+    if (parsed && typeof parsed === 'object') {
+      return { ...parsed, workers: Array.isArray(parsed.workers) ? parsed.workers : [] };
+    }
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+  }
+  return { workers: [] };
+}
+
+function buildWorkerPatch({ id, label, provider, status, sessionId, updatedAt, now, note }) {
+  const workerId = normalizeString(id);
+  if (!workerId) throw new Error('worker id is required');
+
+  const patch = {
+    id: workerId,
+    status: normalizeWorkerStatus(status),
+    updated_at: normalizeString(updatedAt || now || new Date().toISOString()),
+  };
+  const normalizedLabel = normalizeString(label);
+  const normalizedProvider = normalizeString(provider);
+  const normalizedSessionId = normalizeString(sessionId);
+  const normalizedNote = normalizeString(note);
+  if (normalizedLabel) patch.label = normalizedLabel;
+  if (normalizedProvider) patch.provider = normalizedProvider;
+  if (normalizedSessionId) patch.session_id = normalizedSessionId;
+  if (normalizedNote) patch.note = normalizedNote;
+  return patch;
+}
+
+function writeSnapshotAtomic(snapshotPath, snapshot) {
+  fs.mkdirSync(path.dirname(snapshotPath), { recursive: true });
+  const tmpPath = `${snapshotPath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmpPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+  fs.renameSync(tmpPath, snapshotPath);
+}
+
+function upsertWorkerStatus(options) {
+  const snapshotPath = resolveWorkerStatusPath(options.repoDir, options.file);
+  const snapshot = readSnapshot(snapshotPath);
+  const patch = buildWorkerPatch(options);
+  const workers = new Map();
+
+  for (const worker of snapshot.workers) {
+    if (worker && typeof worker === 'object' && normalizeString(worker.id)) {
+      workers.set(normalizeString(worker.id), { ...worker });
+    }
+  }
+
+  workers.set(patch.id, {
+    ...(workers.get(patch.id) || {}),
+    ...patch,
+  });
+
+  const nextSnapshot = {
+    ...snapshot,
+    updated_at: patch.updated_at,
+    workers: Array.from(workers.values()).sort((a, b) => String(a.id).localeCompare(String(b.id))),
+  };
+  writeSnapshotAtomic(snapshotPath, nextSnapshot);
+  return nextSnapshot;
+}
+
+module.exports = {
+  resolveWorkerStatusPath,
+  upsertWorkerStatus,
+};

--- a/lib/workflows.js
+++ b/lib/workflows.js
@@ -147,20 +147,78 @@ function normalizeWorkerStatus(status) {
   return 'unknown';
 }
 
-function normalizeWorkers(definition) {
-  const rawWorkers = getNested(definition, ['execution', 'workers']) || definition.workers || [];
+function normalizeWorker(worker, index = 0, { fallback = true } = {}) {
+  const id = normalizeString(worker.id || worker.name || (fallback ? `worker-${index + 1}` : ''));
+  return {
+    id,
+    label: normalizeString(worker.label || worker.title || worker.name || (fallback ? worker.id || `Worker ${index + 1}` : '')),
+    provider: normalizeString(worker.provider || worker.type || worker.agent || (fallback ? 'unknown' : '')),
+    status: normalizeWorkerStatus(worker.status || worker.state),
+    sessionId: normalizeString(worker.session_id || worker.sessionId || worker.providerSessionId),
+    updatedAt: normalizeString(worker.updated_at || worker.updatedAt || worker.last_seen_at || worker.lastSeenAt),
+    note: normalizeString(worker.note || worker.message || worker.reason),
+  };
+}
+
+function normalizeWorkerList(rawWorkers, options = {}) {
   if (!Array.isArray(rawWorkers)) return [];
   return rawWorkers
     .filter((worker) => worker && typeof worker === 'object')
-    .map((worker, index) => ({
-      id: normalizeString(worker.id || worker.name || `worker-${index + 1}`),
-      label: normalizeString(worker.label || worker.title || worker.name || worker.id || `Worker ${index + 1}`),
-      provider: normalizeString(worker.provider || worker.type || worker.agent || 'unknown'),
-      status: normalizeWorkerStatus(worker.status || worker.state),
-      sessionId: normalizeString(worker.session_id || worker.sessionId || worker.providerSessionId),
-      updatedAt: normalizeString(worker.updated_at || worker.updatedAt || worker.last_seen_at || worker.lastSeenAt),
-      note: normalizeString(worker.note || worker.message || worker.reason),
-    }));
+    .map((worker, index) => normalizeWorker(worker, index, options));
+}
+
+function resolveRepoLocalPath(repoDir, filePath) {
+  const rawPath = normalizeString(filePath);
+  if (!rawPath || path.isAbsolute(rawPath)) return null;
+  const resolvedRepoDir = path.resolve(repoDir);
+  const resolvedPath = path.resolve(resolvedRepoDir, rawPath);
+  const relative = path.relative(resolvedRepoDir, resolvedPath);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return resolvedPath;
+}
+
+function readWorkerStatusSnapshot(repoDir, definition) {
+  const statusFile = getNested(definition, ['execution', 'worker_status_file'])
+    || getNested(definition, ['execution', 'workerStatusFile'])
+    || definition.worker_status_file
+    || definition.workerStatusFile;
+  const snapshotPath = resolveRepoLocalPath(repoDir, statusFile);
+  if (!snapshotPath || !fs.existsSync(snapshotPath)) return [];
+
+  try {
+    const snapshot = readYamlFile(snapshotPath).data;
+    if (Array.isArray(snapshot)) return snapshot;
+    if (Array.isArray(snapshot?.workers)) return snapshot.workers;
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+function mergeWorkerSnapshots(baseWorkers, runtimeWorkers) {
+  const merged = new Map();
+  for (const worker of baseWorkers) merged.set(worker.id, worker);
+  for (const runtimeWorker of runtimeWorkers) {
+    if (!runtimeWorker.id) continue;
+    const previous = merged.get(runtimeWorker.id) || {};
+    merged.set(runtimeWorker.id, {
+      ...previous,
+      ...runtimeWorker,
+      label: runtimeWorker.label || previous.label || runtimeWorker.id,
+      provider: runtimeWorker.provider || previous.provider || 'unknown',
+    });
+  }
+  return Array.from(merged.values());
+}
+
+function normalizeWorkers(definition, { repoDir } = {}) {
+  const rawWorkers = getNested(definition, ['execution', 'workers']) || definition.workers || [];
+  const baseWorkers = normalizeWorkerList(rawWorkers);
+  if (!repoDir) return baseWorkers;
+
+  const runtimeWorkers = normalizeWorkerList(readWorkerStatusSnapshot(repoDir, definition), { fallback: false });
+  if (!runtimeWorkers.length) return baseWorkers;
+  return mergeWorkerSnapshots(baseWorkers, runtimeWorkers);
 }
 
 function emptyWorkerSummary() {
@@ -230,7 +288,7 @@ function buildWorkflowIndex({ repoDir = resolveMiraRepoDir(), cronJobs = [] } = 
     const latestReportPath = findLatestReport(resolvedRepoDir, id);
     const cron = findCronJob(definition, id, cronJobs);
     const health = classifyWorkflow({ runbookPath, cron });
-    const workers = normalizeWorkers(definition);
+    const workers = normalizeWorkers(definition, { repoDir: resolvedRepoDir });
 
     return {
       id,

--- a/lib/workflows.js
+++ b/lib/workflows.js
@@ -1,0 +1,242 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const DEFAULT_REPO_CANDIDATES = [
+  path.join(os.homedir(), 'worktrees', 'MiraRepo_runtime_main'),
+  path.join(os.homedir(), 'repos', 'MiraRepo'),
+];
+
+function resolveMiraRepoDir(explicitDir = process.env.MIRA_REPO_DIR) {
+  const candidates = [explicitDir, ...DEFAULT_REPO_CANDIDATES].filter(Boolean);
+  for (const candidate of candidates) {
+    const resolved = path.resolve(candidate);
+    if (fs.existsSync(path.join(resolved, 'docs', 'workflows'))) return resolved;
+  }
+  return path.resolve(candidates[0] || DEFAULT_REPO_CANDIDATES[0]);
+}
+
+function toPosixRelative(root, filePath) {
+  return path.relative(root, filePath).split(path.sep).join('/');
+}
+
+function listFiles(dir, predicate = () => true) {
+  try {
+    return fs.readdirSync(dir)
+      .map((name) => path.join(dir, name))
+      .filter((filePath) => {
+        try { return fs.statSync(filePath).isFile() && predicate(filePath); }
+        catch { return false; }
+      })
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+function readYamlFile(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const data = yaml.load(raw) || {};
+  return { raw, data };
+}
+
+function getNested(obj, pathParts) {
+  let current = obj;
+  for (const part of pathParts) {
+    if (!current || typeof current !== 'object') return undefined;
+    current = current[part];
+  }
+  return current;
+}
+
+function normalizeString(value) {
+  return String(value || '').trim();
+}
+
+function normalizeKey(value) {
+  return normalizeString(value).toLowerCase();
+}
+
+function pickWorkflowId(filePath, definition) {
+  return normalizeString(definition.id) || path.basename(filePath).replace(/\.(ya?ml)$/i, '');
+}
+
+function findRunbook(repoDir, id, definition) {
+  const linkedRunbook = getNested(definition, ['links', 'runbook']);
+  const candidates = [
+    linkedRunbook && path.resolve(repoDir, linkedRunbook),
+    path.join(repoDir, 'docs', 'workflows', 'runbooks', `${id}.md`),
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (candidate.startsWith(repoDir) && fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function findLatestReport(repoDir, id) {
+  const reportsDir = path.join(repoDir, 'reports', 'workflows');
+  const reports = listFiles(reportsDir, (filePath) => /\.(md|txt|json|ya?ml)$/i.test(filePath))
+    .map((filePath) => {
+      let stat;
+      try { stat = fs.statSync(filePath); } catch { return null; }
+      const base = path.basename(filePath).toLowerCase();
+      const score = base.includes(normalizeKey(id)) ? 2 : 0;
+      return { filePath, mtimeMs: stat.mtimeMs, score };
+    })
+    .filter(Boolean)
+    .filter((item) => item.score > 0)
+    .sort((a, b) => b.score - a.score || b.mtimeMs - a.mtimeMs);
+  return reports[0]?.filePath || null;
+}
+
+function findCronJob(definition, id, cronJobs = []) {
+  const explicitIds = [
+    getNested(definition, ['execution', 'hermes_cron_job_id']),
+    getNested(definition, ['execution', 'cron_job_id']),
+    definition.hermes_cron_job_id,
+    definition.cron_job_id,
+  ].map(normalizeKey).filter(Boolean);
+
+  const names = [id, definition.name].map(normalizeKey).filter(Boolean);
+
+  return cronJobs.find((job) => explicitIds.includes(normalizeKey(job.id)))
+    || cronJobs.find((job) => names.includes(normalizeKey(job.name)) || names.includes(normalizeKey(job.id)))
+    || cronJobs.find((job) => names.some((name) => normalizeKey(job.name).includes(name)))
+    || null;
+}
+
+function classifyWorkflow({ runbookPath, cron }) {
+  const warnings = [];
+  const deliver = normalizeKey(cron?.deliver);
+  const lastDeliveryError = normalizeString(cron?.lastDeliveryError || cron?.deliveryError);
+  const lastStatus = normalizeKey(cron?.lastStatus);
+  const cronStatus = normalizeKey(cron?.status);
+
+  if (lastDeliveryError) {
+    if (deliver === 'local' && /deliver=origin|origin/i.test(lastDeliveryError)) {
+      warnings.push('last_delivery_error appears stale because current delivery is local');
+    } else {
+      return { status: 'active_failure', warnings: [lastDeliveryError] };
+    }
+  }
+
+  if (['failed', 'failure', 'error'].includes(lastStatus) || ['failed', 'failure', 'error'].includes(cronStatus)) {
+    return { status: 'active_failure', warnings: [`cron status indicates ${lastStatus || cronStatus}`] };
+  }
+
+  if (warnings.length) return { status: 'stale_warning', warnings };
+  if (!runbookPath) return { status: 'missing_runbook', warnings: ['runbook is missing'] };
+  if (!cron) return { status: 'missing_cron', warnings: ['cron job is not linked'] };
+  return { status: 'ok', warnings };
+}
+
+function workflowSummary(workflows) {
+  const summary = {
+    total: workflows.length,
+    ok: 0,
+    active_failure: 0,
+    stale_warning: 0,
+    missing_runbook: 0,
+    missing_cron: 0,
+    unknown: 0,
+  };
+  for (const workflow of workflows) {
+    const key = workflow.status || 'unknown';
+    summary[key] = (summary[key] || 0) + 1;
+  }
+  return summary;
+}
+
+function buildWorkflowIndex({ repoDir = resolveMiraRepoDir(), cronJobs = [] } = {}) {
+  const resolvedRepoDir = path.resolve(repoDir);
+  const definitionsDir = path.join(resolvedRepoDir, 'docs', 'workflows', 'definitions');
+  const definitionFiles = listFiles(definitionsDir, (filePath) => /\.ya?ml$/i.test(filePath));
+
+  const workflows = definitionFiles.map((definitionPath) => {
+    let parsed;
+    try {
+      parsed = readYamlFile(definitionPath);
+    } catch (error) {
+      const id = path.basename(definitionPath).replace(/\.(ya?ml)$/i, '');
+      return {
+        id,
+        name: id,
+        definitionPath: toPosixRelative(resolvedRepoDir, definitionPath),
+        runbookPath: null,
+        latestReportPath: null,
+        cron: null,
+        status: 'active_failure',
+        warnings: [`definition parse failed: ${error.message}`],
+      };
+    }
+
+    const definition = parsed.data;
+    const id = pickWorkflowId(definitionPath, definition);
+    const runbookPath = findRunbook(resolvedRepoDir, id, definition);
+    const latestReportPath = findLatestReport(resolvedRepoDir, id);
+    const cron = findCronJob(definition, id, cronJobs);
+    const health = classifyWorkflow({ runbookPath, cron });
+
+    return {
+      id,
+      name: normalizeString(definition.name) || id,
+      businessGoal: normalizeString(definition.business_goal || definition.businessGoal),
+      schedule: getNested(definition, ['schedule', 'human_readable'])
+        || getNested(definition, ['schedule', 'expression'])
+        || normalizeString(cron?.schedule),
+      riskLevel: getNested(definition, ['risk', 'level']) || definition.risk_level || 'unknown',
+      definitionPath: toPosixRelative(resolvedRepoDir, definitionPath),
+      runbookPath: runbookPath ? toPosixRelative(resolvedRepoDir, runbookPath) : null,
+      latestReportPath: latestReportPath ? toPosixRelative(resolvedRepoDir, latestReportPath) : null,
+      cron: cron ? {
+        id: cron.id,
+        name: cron.name,
+        status: cron.status,
+        schedule: cron.schedule,
+        nextRun: cron.nextRun,
+        lastRun: cron.lastRun,
+        lastStatus: cron.lastStatus,
+        deliver: cron.deliver,
+        lastDeliveryError: cron.lastDeliveryError,
+      } : null,
+      status: health.status,
+      warnings: health.warnings,
+    };
+  });
+
+  workflows.sort((a, b) => a.id.localeCompare(b.id));
+  return {
+    repoDir: resolvedRepoDir,
+    workflows,
+    summary: workflowSummary(workflows),
+  };
+}
+
+function getWorkflowDetail({ repoDir = resolveMiraRepoDir(), id, cronJobs = [] } = {}) {
+  const index = buildWorkflowIndex({ repoDir, cronJobs });
+  const workflow = index.workflows.find((item) => item.id === id);
+  if (!workflow) return null;
+  const definitionAbs = path.resolve(index.repoDir, workflow.definitionPath);
+  const runbookAbs = workflow.runbookPath ? path.resolve(index.repoDir, workflow.runbookPath) : null;
+  const reportAbs = workflow.latestReportPath ? path.resolve(index.repoDir, workflow.latestReportPath) : null;
+
+  return {
+    ...workflow,
+    repoDir: index.repoDir,
+    definitionRaw: fs.existsSync(definitionAbs) ? fs.readFileSync(definitionAbs, 'utf8') : '',
+    runbookRaw: runbookAbs && fs.existsSync(runbookAbs) ? fs.readFileSync(runbookAbs, 'utf8') : '',
+    latestReportRaw: reportAbs && fs.existsSync(reportAbs) ? fs.readFileSync(reportAbs, 'utf8').slice(0, 12000) : '',
+  };
+}
+
+module.exports = {
+  buildWorkflowIndex,
+  classifyWorkflow,
+  findCronJob,
+  getWorkflowDetail,
+  resolveMiraRepoDir,
+};

--- a/lib/workflows.js
+++ b/lib/workflows.js
@@ -134,6 +134,54 @@ function classifyWorkflow({ runbookPath, cron }) {
   return { status: 'ok', warnings };
 }
 
+const WORKER_STATUS_KEYS = ['starting', 'generating', 'waiting_approval', 'idle', 'error', 'stopped', 'unknown'];
+
+function normalizeWorkerStatus(status) {
+  const value = normalizeKey(status).replace(/[\s-]+/g, '_');
+  if (['starting', 'booting', 'queued'].includes(value)) return 'starting';
+  if (['generating', 'running', 'busy', 'in_progress', 'working'].includes(value)) return 'generating';
+  if (['waiting_approval', 'approval_required', 'blocked', 'paused_for_approval'].includes(value)) return 'waiting_approval';
+  if (['idle', 'ready', 'complete', 'completed', 'done', 'success', 'ok'].includes(value)) return 'idle';
+  if (['error', 'failed', 'failure', 'crashed', 'timeout'].includes(value)) return 'error';
+  if (['stopped', 'cancelled', 'canceled', 'killed', 'terminated'].includes(value)) return 'stopped';
+  return 'unknown';
+}
+
+function normalizeWorkers(definition) {
+  const rawWorkers = getNested(definition, ['execution', 'workers']) || definition.workers || [];
+  if (!Array.isArray(rawWorkers)) return [];
+  return rawWorkers
+    .filter((worker) => worker && typeof worker === 'object')
+    .map((worker, index) => ({
+      id: normalizeString(worker.id || worker.name || `worker-${index + 1}`),
+      label: normalizeString(worker.label || worker.title || worker.name || worker.id || `Worker ${index + 1}`),
+      provider: normalizeString(worker.provider || worker.type || worker.agent || 'unknown'),
+      status: normalizeWorkerStatus(worker.status || worker.state),
+      sessionId: normalizeString(worker.session_id || worker.sessionId || worker.providerSessionId),
+      updatedAt: normalizeString(worker.updated_at || worker.updatedAt || worker.last_seen_at || worker.lastSeenAt),
+      note: normalizeString(worker.note || worker.message || worker.reason),
+    }));
+}
+
+function emptyWorkerSummary() {
+  return WORKER_STATUS_KEYS.reduce((summary, status) => {
+    summary[status] = 0;
+    return summary;
+  }, { total: 0 });
+}
+
+function summarizeWorkers(workflows) {
+  const summary = emptyWorkerSummary();
+  for (const workflow of workflows) {
+    for (const worker of workflow.workers || []) {
+      summary.total += 1;
+      const status = WORKER_STATUS_KEYS.includes(worker.status) ? worker.status : 'unknown';
+      summary[status] += 1;
+    }
+  }
+  return summary;
+}
+
 function workflowSummary(workflows) {
   const summary = {
     total: workflows.length,
@@ -143,11 +191,13 @@ function workflowSummary(workflows) {
     missing_runbook: 0,
     missing_cron: 0,
     unknown: 0,
+    workers: emptyWorkerSummary(),
   };
   for (const workflow of workflows) {
     const key = workflow.status || 'unknown';
     summary[key] = (summary[key] || 0) + 1;
   }
+  summary.workers = summarizeWorkers(workflows);
   return summary;
 }
 
@@ -180,6 +230,7 @@ function buildWorkflowIndex({ repoDir = resolveMiraRepoDir(), cronJobs = [] } = 
     const latestReportPath = findLatestReport(resolvedRepoDir, id);
     const cron = findCronJob(definition, id, cronJobs);
     const health = classifyWorkflow({ runbookPath, cron });
+    const workers = normalizeWorkers(definition);
 
     return {
       id,
@@ -203,6 +254,7 @@ function buildWorkflowIndex({ repoDir = resolveMiraRepoDir(), cronJobs = [] } = 
         deliver: cron.deliver,
         lastDeliveryError: cron.lastDeliveryError,
       } : null,
+      workers,
       status: health.status,
       warnings: health.warnings,
     };
@@ -238,5 +290,8 @@ module.exports = {
   classifyWorkflow,
   findCronJob,
   getWorkflowDetail,
+  normalizeWorkerStatus,
+  normalizeWorkers,
   resolveMiraRepoDir,
+  summarizeWorkers,
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "setup": "bash install.sh",
     "test": "node --test",
     "worker-status": "node scripts/workflow-worker-status.js",
-    "reset-password": "node scripts/reset-password.js"
+    "reset-password": "node scripts/reset-password.js",
+    "worker-run": "node scripts/workflow-worker-run.js"
   },
   "dependencies": {
     "@pydantic/genai-prices": "^0.0.56",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "serve": "node server.js",
     "setup": "bash install.sh",
     "test": "node --test",
+    "worker-status": "node scripts/workflow-worker-status.js",
     "reset-password": "node scripts/reset-password.js"
   },
   "dependencies": {

--- a/scripts/workflow-worker-run.js
+++ b/scripts/workflow-worker-run.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+const { runWorkerCommand } = require('../lib/workflow-worker-runner');
+
+function usage() {
+  return `Usage: node scripts/workflow-worker-run.js --repo <repo> --file <relative-json> --id <worker-id> --provider <provider> -- <command> [args...]
+
+Options:
+  --label <label>             Human label shown in HCI
+  --provider <provider>       codex | claude | hermes | other
+  --session-id <id>           Provider/session id
+  --cwd <dir>                 Working directory for command (defaults to repo)
+  --start-note <text>         Note written with generating status
+
+Examples:
+  node scripts/workflow-worker-run.js \
+    --repo ~/repos/MiraRepo \
+    --file reports/workflows/runtime/mira-hci.json \
+    --id codex-lane-1 \
+    --label "Codex Lane 1" \
+    --provider codex \
+    -- codex --ask-for-approval on-request "Implement issue #123"
+
+  node scripts/workflow-worker-run.js \
+    --repo ~/repos/MiraRepo \
+    --file reports/workflows/runtime/mira-hci.json \
+    --id hermes-lane \
+    --provider hermes \
+    -- hermes -p default "Run the workflow"
+`;
+}
+
+function parseArgs(argv) {
+  const separatorIndex = argv.indexOf('--');
+  const optionTokens = separatorIndex === -1 ? argv : argv.slice(0, separatorIndex);
+  const commandTokens = separatorIndex === -1 ? [] : argv.slice(separatorIndex + 1);
+  const args = {};
+
+  for (let index = 0; index < optionTokens.length; index += 1) {
+    const item = optionTokens[index];
+    if (item === '--help' || item === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (!item.startsWith('--')) throw new Error(`unexpected argument: ${item}`);
+    const key = item.slice(2).replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+    const value = optionTokens[index + 1];
+    if (!value || value.startsWith('--')) throw new Error(`missing value for ${item}`);
+    args[key] = value;
+    index += 1;
+  }
+
+  args.command = commandTokens[0];
+  args.commandArgs = commandTokens.slice(1);
+  return args;
+}
+
+function expandHome(value) {
+  if (!value || !value.startsWith('~/')) return value;
+  return `${process.env.HOME || ''}/${value.slice(2)}`;
+}
+
+function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    process.stdout.write(usage());
+    return 0;
+  }
+  if (!args.command) throw new Error('command is required after --');
+
+  const result = runWorkerCommand({
+    repoDir: expandHome(args.repo),
+    file: args.file,
+    id: args.id,
+    label: args.label,
+    provider: args.provider || args.statusProvider,
+    sessionId: args.sessionId,
+    cwd: expandHome(args.cwd),
+    startNote: args.startNote,
+    command: args.command,
+    args: args.commandArgs,
+  });
+
+  return result.exitCode;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    process.stderr.write(`${error.message}\n\n${usage()}`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = { main, parseArgs };

--- a/scripts/workflow-worker-status.js
+++ b/scripts/workflow-worker-status.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+const { upsertWorkerStatus } = require('../lib/workflow-worker-status');
+
+function usage() {
+  return `Usage: node scripts/workflow-worker-status.js --repo <repo> --file <relative-json> --id <worker-id> --status <status> [options]
+
+Options:
+  --label <label>          Human label shown in HCI
+  --provider <provider>    codex | claude | hermes | other
+  --session-id <id>        Provider/session id
+  --note <text>            Short status note
+  --updated-at <iso>       Override timestamp
+
+Example:
+  node scripts/workflow-worker-status.js \\
+    --repo ~/repos/MiraRepo \\
+    --file reports/workflows/runtime/mira-hci.json \\
+    --id codex-lane-1 \\
+    --label "Codex Lane 1" \\
+    --provider codex \\
+    --status running \\
+    --session-id codex-abc123
+`;
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const item = argv[index];
+    if (item === '--help' || item === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (!item.startsWith('--')) {
+      throw new Error(`unexpected argument: ${item}`);
+    }
+    const key = item.slice(2).replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+    const value = argv[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error(`missing value for ${item}`);
+    }
+    args[key] = value;
+    index += 1;
+  }
+  return args;
+}
+
+function expandHome(value) {
+  if (!value || !value.startsWith('~/')) return value;
+  return `${process.env.HOME || ''}/${value.slice(2)}`;
+}
+
+function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    process.stdout.write(usage());
+    return 0;
+  }
+
+  const snapshot = upsertWorkerStatus({
+    repoDir: expandHome(args.repo),
+    file: args.file,
+    id: args.id,
+    label: args.label,
+    provider: args.provider,
+    status: args.status,
+    sessionId: args.sessionId,
+    updatedAt: args.updatedAt,
+    note: args.note,
+  });
+
+  process.stdout.write(`${JSON.stringify({ ok: true, total: snapshot.workers.length, worker: args.id }, null, 2)}\n`);
+  return 0;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    process.stderr.write(`${error.message}\n\n${usage()}`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = { main, parseArgs };

--- a/server.js
+++ b/server.js
@@ -17,6 +17,11 @@ const {
   mergeSessionsFromSources,
   parseHermesSessionsList,
 } = require('./lib/session-list');
+const {
+  buildWorkflowIndex,
+  getWorkflowDetail,
+  resolveMiraRepoDir,
+} = require('./lib/workflows');
 
 // ── TUI Gateway Bridge ──
 const { getBridge, killAllBridges } = require('./lib/tui-gateway-bridge');
@@ -1211,6 +1216,11 @@ function parseHermesCronList(raw) {
       continue;
     }
     if (!current) continue;
+    const deliveryFailed = trimmed.match(/Delivery failed:\s*(.*)$/i);
+    if (deliveryFailed) {
+      current.lastDeliveryError = deliveryFailed[1].trim();
+      continue;
+    }
     const kv = trimmed.match(/^([A-Za-z ]+):\s*(.*)$/);
     if (!kv) continue;
     const key = kv[1].toLowerCase();
@@ -1219,8 +1229,14 @@ function parseHermesCronList(raw) {
     else if (key === 'schedule') current.schedule = value || 'n/a';
     else if (key === 'repeat') current.repeat = value || null;
     else if (key === 'next run') current.nextRun = value || null;
-    else if (key === 'last run') current.lastRun = value || null;
+    else if (key === 'last run') {
+      current.lastRun = value || null;
+      const statusMatch = value.match(/\s+(ok|failed|failure|error|cancelled|timeout)\s*$/i);
+      if (statusMatch) current.lastStatus = statusMatch[1].toLowerCase();
+    }
     else if (key === 'deliver') current.deliver = value || 'n/a';
+    else if (key === 'last status') current.lastStatus = value || null;
+    else if (key === 'last delivery error') current.lastDeliveryError = value || null;
   }
   flush();
   return jobs;
@@ -2791,6 +2807,29 @@ app.post('/api/cron/:action', requireAuth, requireCsrf, requirePerm('cron.manage
     return res.json(result);
   } catch (error) {
     return res.status(error.statusCode || 400).json({ error: error.message || 'cron action failed' });
+  }
+});
+
+app.get('/api/workflows', requireAuth, async (req, res) => {
+  try {
+    const repoDir = resolveMiraRepoDir(req.query.repoDir || process.env.MIRA_REPO_DIR);
+    const cronJobsData = await getCronJobs();
+    const result = buildWorkflowIndex({ repoDir, cronJobs: cronJobsData });
+    return res.json({ ok: true, ...result });
+  } catch (error) {
+    return res.status(500).json({ ok: false, error: error.message || 'failed to load workflows' });
+  }
+});
+
+app.get('/api/workflows/:id', requireAuth, async (req, res) => {
+  try {
+    const repoDir = resolveMiraRepoDir(req.query.repoDir || process.env.MIRA_REPO_DIR);
+    const cronJobsData = await getCronJobs();
+    const workflow = getWorkflowDetail({ repoDir, id: req.params.id, cronJobs: cronJobsData });
+    if (!workflow) return res.status(404).json({ ok: false, error: 'workflow not found' });
+    return res.json({ ok: true, workflow });
+  } catch (error) {
+    return res.status(500).json({ ok: false, error: error.message || 'failed to load workflow' });
   }
 });
 

--- a/server.js
+++ b/server.js
@@ -99,9 +99,14 @@ function shell(cmd, timeout = '8s') {
 }
 
 // Safer execution — no bash interpretation, direct args
+const HERMES_CLI = process.env.HERMES_CLI
+  || path.join(os.homedir(), '.hermes', 'hermes-agent', 'venv', 'bin', 'hermes')
+  || 'hermes';
+
 function execHermes(args, timeout = 30000) {
+  const command = fs.existsSync(HERMES_CLI) ? HERMES_CLI : 'hermes';
   return new Promise((resolve) => {
-    execFile('hermes', args, {
+    execFile(command, args, {
       encoding: 'utf8',
       maxBuffer: 64 * 1024,
       timeout,
@@ -1245,7 +1250,7 @@ function parseHermesCronList(raw) {
 async function getCronJobs() {
   const now = Date.now();
   if (getCronJobs.cache && now - getCronJobs.cache.at < 10_000) return getCronJobs.cache.data;
-  const raw = await shell('hermes cron list');
+  const raw = await execHermes(['cron', 'list', '--all'], 15000);
   if (raw) {
     const data = parseHermesCronList(raw);
     getCronJobs.cache = { at: now, data };

--- a/src/css/components.css
+++ b/src/css/components.css
@@ -163,6 +163,81 @@
   gap: 16px;
 }
 
+/* Workflows */
+.workflow-source {
+  margin: -8px 0 16px;
+  color: var(--fg-muted);
+  font-size: 12px;
+}
+.workflow-summary-grid {
+  grid-template-columns: repeat(4, minmax(120px, 1fr));
+  margin-bottom: 18px;
+}
+.workflow-summary-card {
+  min-height: 72px;
+}
+.workflow-summary-value {
+  margin-top: 10px;
+  font-size: 28px;
+  font-weight: 700;
+}
+.workflow-table td {
+  vertical-align: top;
+}
+.workflow-name {
+  font-weight: 700;
+  color: var(--fg);
+}
+.workflow-muted,
+.workflow-goal {
+  margin-top: 4px;
+  color: var(--fg-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.workflow-goal {
+  max-width: 360px;
+}
+.workflow-warning {
+  margin-top: 6px;
+  color: var(--amber);
+  font-size: 12px;
+  line-height: 1.4;
+  max-width: 260px;
+}
+.workflow-warning-block {
+  margin: 14px 0;
+  padding: 10px;
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  border-radius: var(--radius);
+  background: rgba(245, 158, 11, 0.08);
+  color: var(--amber);
+  font-size: 12px;
+}
+.workflow-detail-modal {
+  width: min(980px, 94vw);
+  max-height: 90vh;
+  overflow: auto;
+}
+.workflow-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(120px, 1fr));
+  gap: 12px;
+  margin-top: 14px;
+  font-size: 13px;
+}
+.workflow-detail-body {
+  max-height: 46vh;
+  overflow: auto;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-panel);
+  color: var(--fg);
+  white-space: pre-wrap;
+  font-size: 12px;
+}
+
 /* Home image card */
 .home-image-card {
   background: var(--bg-card);

--- a/src/css/components.css
+++ b/src/css/components.css
@@ -170,7 +170,7 @@
   font-size: 12px;
 }
 .workflow-summary-grid {
-  grid-template-columns: repeat(4, minmax(120px, 1fr));
+  grid-template-columns: repeat(5, minmax(120px, 1fr));
   margin-bottom: 18px;
 }
 .workflow-summary-card {
@@ -197,6 +197,15 @@
 }
 .workflow-goal {
   max-width: 360px;
+}
+.workflow-worker-row {
+  display: grid;
+  gap: 3px;
+  margin-bottom: 8px;
+  min-width: 150px;
+}
+.workflow-worker-row .badge {
+  width: fit-content;
 }
 .workflow-warning {
   margin-top: 6px;

--- a/src/index.html
+++ b/src/index.html
@@ -54,6 +54,7 @@
         <a href="#agents" class="nav-link" data-page="agents">Agents</a>
         <a href="#usage" class="nav-link" data-page="usage">Usage</a>
         <a href="#skills" class="nav-link" data-page="skills">Skills</a>
+        <a href="#workflows" class="nav-link" data-page="workflows">Workflows</a>
 <a href="#chat" class="nav-link" data-page="chat">Chat</a>
 <a href="#logs" class="nav-link" data-page="logs">Logs</a>
 <a href="#maintenance" class="nav-link" data-page="maintenance">Maintenance</a>
@@ -101,6 +102,7 @@
       <div id="page-agent-detail" class="page"></div>
       <div id="page-usage" class="page"></div>
       <div id="page-skills" class="page"></div>
+      <div id="page-workflows" class="page"></div>
       <div id="page-chat" class="page"></div>
       <div id="page-users" class="page"></div>
       <div id="page-logs" class="page"></div>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -5988,8 +5988,30 @@ function workflowStatusClass(status) {
   return 'status-off';
 }
 
+function workerStatusClass(status) {
+  if (status === 'idle') return 'status-ok';
+  if (status === 'starting' || status === 'generating') return 'status-warn';
+  if (status === 'waiting_approval') return 'status-err';
+  if (status === 'error') return 'status-err';
+  if (status === 'stopped') return 'status-off';
+  return 'status-off';
+}
+
 function formatWorkflowStatus(status) {
   return String(status || 'unknown').replace(/_/g, ' ');
+}
+
+function renderWorkerSummary(summary = {}) {
+  const workers = summary.workers || {};
+  const active = (workers.starting || 0) + (workers.generating || 0);
+  const attention = (workers.waiting_approval || 0) + (workers.error || 0);
+  return `
+    <div class="card workflow-summary-card">
+      <div class="card-title">Workers</div>
+      <div class="workflow-summary-value status-off">${escapeHtml(workers.total || 0)}</div>
+      <div class="workflow-muted">active: ${escapeHtml(active)} · attention: ${escapeHtml(attention)}</div>
+    </div>
+  `;
 }
 
 function renderWorkflowSummary(summary = {}) {
@@ -6004,7 +6026,18 @@ function renderWorkflowSummary(summary = {}) {
       <div class="card-title">${escapeHtml(label)}</div>
       <div class="workflow-summary-value ${cls}">${escapeHtml(value)}</div>
     </div>
-  `).join('');
+  `).join('') + renderWorkerSummary(summary);
+}
+
+function renderWorkflowWorkers(workers = []) {
+  if (!workers.length) return '<span class="workflow-muted">No workers</span>';
+  return workers.slice(0, 3).map((worker) => `
+    <div class="workflow-worker-row">
+      <span class="badge ${workerStatusClass(worker.status)}">${escapeHtml(formatWorkflowStatus(worker.status))}</span>
+      <span>${escapeHtml(worker.label || worker.id)}</span>
+      <div class="workflow-muted">${escapeHtml(worker.provider || 'unknown')}${worker.sessionId ? ` · ${escapeHtml(worker.sessionId)}` : ''}</div>
+    </div>
+  `).join('') + (workers.length > 3 ? `<div class="workflow-muted">+${escapeHtml(workers.length - 3)} more</div>` : '');
 }
 
 function renderWorkflowRows(workflows = []) {
@@ -6019,6 +6052,7 @@ function renderWorkflowRows(workflows = []) {
             <th>Workflow</th>
             <th>Status</th>
             <th>Schedule</th>
+            <th>Workers</th>
             <th>Cron</th>
             <th>Artifacts</th>
             <th></th>
@@ -6037,6 +6071,7 @@ function renderWorkflowRows(workflows = []) {
                 ${(workflow.warnings || []).slice(0, 2).map((warning) => `<div class="workflow-warning">${escapeHtml(warning)}</div>`).join('')}
               </td>
               <td>${escapeHtml(workflow.schedule || 'n/a')}</td>
+              <td>${renderWorkflowWorkers(workflow.workers || [])}</td>
               <td>
                 ${workflow.cron ? `
                   <div>${escapeHtml(workflow.cron.name || workflow.cron.id)}</div>
@@ -6097,6 +6132,7 @@ window.showWorkflowDetail = async function(id) {
         <div><strong>Status</strong><br><span class="badge ${workflowStatusClass(workflow.status)}">${escapeHtml(formatWorkflowStatus(workflow.status))}</span></div>
         <div><strong>Schedule</strong><br>${escapeHtml(workflow.schedule || 'n/a')}</div>
         <div><strong>Risk</strong><br>${escapeHtml(workflow.riskLevel || 'unknown')}</div>
+        <div><strong>Workers</strong><br>${renderWorkflowWorkers(workflow.workers || [])}</div>
         <div><strong>Cron</strong><br>${workflow.cron ? `${escapeHtml(workflow.cron.name || workflow.cron.id)}<br><span class="workflow-muted">${escapeHtml(workflow.cron.id || '')}</span>` : 'Not linked'}</div>
       </div>
       ${(workflow.warnings || []).length ? `<div class="workflow-warning-block">${(workflow.warnings || []).map((w) => `<div>⚠ ${escapeHtml(w)}</div>`).join('')}</div>` : ''}

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -272,6 +272,9 @@ async function loadPage(page, params = {}) {
       case 'skills':
         await loadSkills(container);
         break;
+      case 'workflows':
+        await loadWorkflows(container);
+        break;
       case 'maintenance':
         await loadMaintenance(container);
         break;
@@ -5797,6 +5800,156 @@ window.markAllNotifRead = async function() {
   try { await api('/api/notifications/clear', { method: 'POST' }); } catch {}
   state.notifDisplayLimit = 5;
   renderNotifications();
+};
+
+
+// ============================================
+// Workflows
+// ============================================
+function workflowStatusClass(status) {
+  if (status === 'ok') return 'status-ok';
+  if (status === 'stale_warning' || status === 'missing_runbook' || status === 'missing_cron') return 'status-warn';
+  if (status === 'active_failure') return 'status-err';
+  return 'status-off';
+}
+
+function formatWorkflowStatus(status) {
+  return String(status || 'unknown').replace(/_/g, ' ');
+}
+
+function renderWorkflowSummary(summary = {}) {
+  const items = [
+    ['Total', summary.total || 0, 'status-off'],
+    ['OK', summary.ok || 0, 'status-ok'],
+    ['Warnings', (summary.stale_warning || 0) + (summary.missing_runbook || 0) + (summary.missing_cron || 0), 'status-warn'],
+    ['Failures', summary.active_failure || 0, 'status-err'],
+  ];
+  return items.map(([label, value, cls]) => `
+    <div class="card workflow-summary-card">
+      <div class="card-title">${escapeHtml(label)}</div>
+      <div class="workflow-summary-value ${cls}">${escapeHtml(value)}</div>
+    </div>
+  `).join('');
+}
+
+function renderWorkflowRows(workflows = []) {
+  if (!workflows.length) {
+    return '<div class="empty">No workflow definitions found in docs/workflows/definitions.</div>';
+  }
+  return `
+    <div class="table-wrap">
+      <table class="data-table workflow-table">
+        <thead>
+          <tr>
+            <th>Workflow</th>
+            <th>Status</th>
+            <th>Schedule</th>
+            <th>Cron</th>
+            <th>Artifacts</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          ${workflows.map((workflow) => `
+            <tr>
+              <td>
+                <div class="workflow-name">${escapeHtml(workflow.name || workflow.id)}</div>
+                <div class="workflow-muted">${escapeHtml(workflow.id)}</div>
+                ${workflow.businessGoal ? `<div class="workflow-goal">${escapeHtml(workflow.businessGoal)}</div>` : ''}
+              </td>
+              <td>
+                <span class="badge ${workflowStatusClass(workflow.status)}">${escapeHtml(formatWorkflowStatus(workflow.status))}</span>
+                ${(workflow.warnings || []).slice(0, 2).map((warning) => `<div class="workflow-warning">${escapeHtml(warning)}</div>`).join('')}
+              </td>
+              <td>${escapeHtml(workflow.schedule || 'n/a')}</td>
+              <td>
+                ${workflow.cron ? `
+                  <div>${escapeHtml(workflow.cron.name || workflow.cron.id)}</div>
+                  <div class="workflow-muted">${escapeHtml(workflow.cron.id || '')} · ${escapeHtml(workflow.cron.status || 'unknown')}</div>
+                  <div class="workflow-muted">deliver: ${escapeHtml(workflow.cron.deliver || 'n/a')}</div>
+                ` : '<span class="workflow-muted">Not linked</span>'}
+              </td>
+              <td>
+                <div class="workflow-muted">definition: ${escapeHtml(workflow.definitionPath || 'n/a')}</div>
+                <div class="workflow-muted">runbook: ${escapeHtml(workflow.runbookPath || 'missing')}</div>
+                ${workflow.latestReportPath ? `<div class="workflow-muted">report: ${escapeHtml(workflow.latestReportPath)}</div>` : ''}
+              </td>
+              <td><button class="btn btn-ghost btn-sm" onclick="window.showWorkflowDetail('${escapeHtml(workflow.id)}')">Details</button></td>
+            </tr>
+          `).join('')}
+        </tbody>
+      </table>
+    </div>
+  `;
+}
+
+async function loadWorkflows(container) {
+  const res = await api('/api/workflows');
+  if (!res.ok) {
+    container.innerHTML = `<div class="empty">Failed to load workflows: ${escapeHtml(res.error || 'unknown error')}</div>`;
+    return;
+  }
+
+  container.innerHTML = `
+    <div class="page-header">
+      <div>
+        <h1>Workflows</h1>
+        <p class="page-subtitle">Read-only Mira workflow inventory from MiraRepo definitions, runbooks, reports, and Hermes cron.</p>
+      </div>
+      <button class="btn btn-ghost" onclick="navigate('workflows')">↻ Refresh</button>
+    </div>
+    <div class="workflow-source">Source: ${escapeHtml(res.repoDir || '')}</div>
+    <div class="card-grid workflow-summary-grid">${renderWorkflowSummary(res.summary)}</div>
+    ${renderWorkflowRows(res.workflows || [])}
+  `;
+}
+
+window.showWorkflowDetail = async function(id) {
+  const res = await api(`/api/workflows/${encodeURIComponent(id)}`);
+  if (!res.ok) {
+    showToast(`Failed to load workflow: ${res.error || 'unknown error'}`, 'error');
+    return;
+  }
+  const workflow = res.workflow || {};
+  const overlay = document.createElement('div');
+  overlay.className = 'modal-overlay';
+  overlay.onclick = (e) => { if (e.target === overlay) overlay.remove(); };
+  overlay.innerHTML = `
+    <div class="modal-card workflow-detail-modal">
+      <div class="modal-title">${escapeHtml(workflow.name || workflow.id)}</div>
+      <div class="workflow-muted">${escapeHtml(workflow.id || '')}</div>
+      <div class="workflow-detail-grid">
+        <div><strong>Status</strong><br><span class="badge ${workflowStatusClass(workflow.status)}">${escapeHtml(formatWorkflowStatus(workflow.status))}</span></div>
+        <div><strong>Schedule</strong><br>${escapeHtml(workflow.schedule || 'n/a')}</div>
+        <div><strong>Risk</strong><br>${escapeHtml(workflow.riskLevel || 'unknown')}</div>
+        <div><strong>Cron</strong><br>${workflow.cron ? `${escapeHtml(workflow.cron.name || workflow.cron.id)}<br><span class="workflow-muted">${escapeHtml(workflow.cron.id || '')}</span>` : 'Not linked'}</div>
+      </div>
+      ${(workflow.warnings || []).length ? `<div class="workflow-warning-block">${(workflow.warnings || []).map((w) => `<div>⚠ ${escapeHtml(w)}</div>`).join('')}</div>` : ''}
+      <div class="tabs workflow-detail-tabs">
+        <button class="tab active" data-target="definition">Definition</button>
+        <button class="tab" data-target="runbook">Runbook</button>
+        <button class="tab" data-target="report">Latest Report</button>
+      </div>
+      <pre id="workflow-detail-body" class="workflow-detail-body">${escapeHtml(workflow.definitionRaw || '')}</pre>
+      <div class="modal-actions">
+        <button class="btn btn-ghost" onclick="this.closest('.modal-overlay').remove()">Close</button>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(overlay);
+  const body = overlay.querySelector('#workflow-detail-body');
+  const payloads = {
+    definition: workflow.definitionRaw || '',
+    runbook: workflow.runbookRaw || 'Runbook is missing.',
+    report: workflow.latestReportRaw || 'No report found.',
+  };
+  overlay.querySelectorAll('.workflow-detail-tabs .tab').forEach((tab) => {
+    tab.addEventListener('click', () => {
+      overlay.querySelectorAll('.workflow-detail-tabs .tab').forEach((t) => t.classList.remove('active'));
+      tab.classList.add('active');
+      body.textContent = payloads[tab.dataset.target] || '';
+    });
+  });
 };
 
 // ============================================

--- a/test/workflow-worker-runner.test.js
+++ b/test/workflow-worker-runner.test.js
@@ -1,0 +1,88 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const { runWorkerCommand, statusForExit } = require('../lib/workflow-worker-runner');
+const { parseArgs } = require('../scripts/workflow-worker-run');
+
+function makeRepo() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'hci-worker-runner-'));
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+test('runWorkerCommand marks a worker generating before launch and idle after success', () => {
+  const repoDir = makeRepo();
+  const file = 'reports/workflows/runtime/sample.json';
+  const writes = [];
+
+  const result = runWorkerCommand({
+    repoDir,
+    file,
+    id: 'codex-lane',
+    label: 'Codex Lane',
+    provider: 'codex',
+    command: process.execPath,
+    args: ['-e', 'process.exit(0)'],
+    now: () => `2026-05-31T14:00:0${writes.length}.000Z`,
+    onStatus: (snapshot) => writes.push(snapshot.workers[0].status),
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(writes, ['generating', 'idle']);
+
+  const snapshot = readJson(path.join(repoDir, file));
+  assert.equal(snapshot.workers[0].id, 'codex-lane');
+  assert.equal(snapshot.workers[0].label, 'Codex Lane');
+  assert.equal(snapshot.workers[0].provider, 'codex');
+  assert.equal(snapshot.workers[0].status, 'idle');
+  assert.match(snapshot.workers[0].note, /exited 0/);
+});
+
+test('runWorkerCommand marks a worker error after failed command', () => {
+  const repoDir = makeRepo();
+  const file = 'reports/workflows/runtime/sample.json';
+
+  const result = runWorkerCommand({
+    repoDir,
+    file,
+    id: 'claude-lane',
+    provider: 'claude',
+    command: process.execPath,
+    args: ['-e', 'process.exit(7)'],
+    now: () => '2026-05-31T14:00:00.000Z',
+  });
+
+  assert.equal(result.exitCode, 7);
+  const snapshot = readJson(path.join(repoDir, file));
+  assert.equal(snapshot.workers[0].status, 'error');
+  assert.match(snapshot.workers[0].note, /exited 7/);
+});
+
+test('workflow worker run CLI parser separates wrapper options from command args', () => {
+  const args = parseArgs([
+    '--repo', '~/repos/MiraRepo',
+    '--file', 'reports/workflows/runtime/sample.json',
+    '--id', 'codex-lane',
+    '--provider', 'codex',
+    '--', 'codex', '--ask-for-approval', 'on-request', 'Do the task',
+  ]);
+
+  assert.equal(args.repo, '~/repos/MiraRepo');
+  assert.equal(args.file, 'reports/workflows/runtime/sample.json');
+  assert.equal(args.id, 'codex-lane');
+  assert.equal(args.provider, 'codex');
+  assert.equal(args.command, 'codex');
+  assert.deepEqual(args.commandArgs, ['--ask-for-approval', 'on-request', 'Do the task']);
+});
+
+test('statusForExit maps signal termination to stopped', () => {
+  assert.equal(statusForExit({ status: null, signal: 'SIGTERM' }), 'stopped');
+  assert.equal(statusForExit({ status: 130, signal: null }), 'stopped');
+  assert.equal(statusForExit({ status: 0, signal: null }), 'idle');
+  assert.equal(statusForExit({ status: 1, signal: null }), 'error');
+});

--- a/test/workflow-worker-status.test.js
+++ b/test/workflow-worker-status.test.js
@@ -1,0 +1,80 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  resolveWorkerStatusPath,
+  upsertWorkerStatus,
+} = require('../lib/workflow-worker-status');
+
+function makeRepo() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'hci-worker-status-'));
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+test('upsertWorkerStatus writes a repo-local snapshot and updates workers by id', () => {
+  const repoDir = makeRepo();
+  const file = 'reports/workflows/runtime/sample.json';
+
+  const first = upsertWorkerStatus({
+    repoDir,
+    file,
+    id: 'codex-lane',
+    label: 'Codex Lane',
+    provider: 'codex',
+    status: 'running',
+    sessionId: 'session-1',
+    note: 'started',
+    now: '2026-05-31T14:00:00.000Z',
+  });
+
+  assert.equal(first.workers.length, 1);
+  assert.equal(first.workers[0].status, 'generating');
+  assert.equal(first.workers[0].session_id, 'session-1');
+  assert.equal(first.workers[0].updated_at, '2026-05-31T14:00:00.000Z');
+
+  upsertWorkerStatus({
+    repoDir,
+    file,
+    id: 'codex-lane',
+    status: 'blocked',
+    sessionId: 'session-2',
+    note: 'approval required',
+    now: '2026-05-31T14:03:00.000Z',
+  });
+
+  const snapshotPath = path.join(repoDir, file);
+  const snapshot = readJson(snapshotPath);
+  assert.equal(snapshot.workers.length, 1);
+  assert.equal(snapshot.workers[0].label, 'Codex Lane');
+  assert.equal(snapshot.workers[0].provider, 'codex');
+  assert.equal(snapshot.workers[0].status, 'waiting_approval');
+  assert.equal(snapshot.workers[0].session_id, 'session-2');
+  assert.equal(snapshot.workers[0].note, 'approval required');
+});
+
+test('upsertWorkerStatus preserves other workers and sorts ids for stable snapshots', () => {
+  const repoDir = makeRepo();
+  const file = 'reports/workflows/runtime/sample.json';
+  fs.mkdirSync(path.join(repoDir, 'reports', 'workflows', 'runtime'), { recursive: true });
+  fs.writeFileSync(path.join(repoDir, file), JSON.stringify({
+    workers: [{ id: 'zeta', status: 'idle' }],
+  }));
+
+  upsertWorkerStatus({ repoDir, file, id: 'alpha', status: 'running', now: '2026-05-31T14:00:00.000Z' });
+
+  const snapshot = readJson(path.join(repoDir, file));
+  assert.deepEqual(snapshot.workers.map((worker) => worker.id), ['alpha', 'zeta']);
+});
+
+test('resolveWorkerStatusPath rejects absolute paths and traversal outside the repo', () => {
+  const repoDir = makeRepo();
+
+  assert.throws(() => resolveWorkerStatusPath(repoDir, '/tmp/outside.json'), /repo-local relative path/);
+  assert.throws(() => resolveWorkerStatusPath(repoDir, '../outside.json'), /outside repo/);
+});

--- a/test/workflows.test.js
+++ b/test/workflows.test.js
@@ -1,0 +1,86 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  buildWorkflowIndex,
+  getWorkflowDetail,
+} = require('../lib/workflows');
+
+function makeRepo() {
+  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hci-workflows-'));
+  fs.mkdirSync(path.join(repoDir, 'docs', 'workflows', 'definitions'), { recursive: true });
+  fs.mkdirSync(path.join(repoDir, 'docs', 'workflows', 'runbooks'), { recursive: true });
+  fs.mkdirSync(path.join(repoDir, 'reports', 'workflows'), { recursive: true });
+  return repoDir;
+}
+
+test('buildWorkflowIndex reads MiraRepo workflow definitions and links cron/runbook/report', () => {
+  const repoDir = makeRepo();
+  fs.writeFileSync(path.join(repoDir, 'docs', 'workflows', 'definitions', 'weekly-memory-refactor.yaml'), `id: weekly-memory-refactor
+name: Weekly Memory Refactor
+business_goal: Keep memory concise
+schedule:
+  human_readable: Weekly Monday 06:30 JST
+risk:
+  level: low
+execution:
+  hermes_cron_job_id: d27468bad831
+links:
+  runbook: docs/workflows/runbooks/weekly-memory-refactor.md
+`);
+  fs.writeFileSync(path.join(repoDir, 'docs', 'workflows', 'runbooks', 'weekly-memory-refactor.md'), '# Runbook\n');
+  fs.writeFileSync(path.join(repoDir, 'reports', 'workflows', 'weekly-memory-refactor-report.md'), '# Report\n');
+
+  const index = buildWorkflowIndex({
+    repoDir,
+    cronJobs: [{
+      id: 'd27468bad831',
+      name: 'weekly-memory-refactor',
+      status: 'active',
+      schedule: '0 6 * * 1',
+      deliver: 'local',
+    }],
+  });
+
+  assert.equal(index.summary.total, 1);
+  assert.equal(index.summary.ok, 1);
+  assert.equal(index.workflows[0].id, 'weekly-memory-refactor');
+  assert.equal(index.workflows[0].cron.id, 'd27468bad831');
+  assert.equal(index.workflows[0].runbookPath, 'docs/workflows/runbooks/weekly-memory-refactor.md');
+  assert.equal(index.workflows[0].latestReportPath, 'reports/workflows/weekly-memory-refactor-report.md');
+});
+
+test('getWorkflowDetail exposes raw definition and runbook without mutating files', () => {
+  const repoDir = makeRepo();
+  fs.writeFileSync(path.join(repoDir, 'docs', 'workflows', 'definitions', 'sample.yaml'), 'id: sample\nname: Sample\n');
+  fs.writeFileSync(path.join(repoDir, 'docs', 'workflows', 'runbooks', 'sample.md'), '# Sample Runbook\n');
+
+  const detail = getWorkflowDetail({ repoDir, id: 'sample', cronJobs: [] });
+
+  assert.equal(detail.id, 'sample');
+  assert.match(detail.definitionRaw, /id: sample/);
+  assert.match(detail.runbookRaw, /Sample Runbook/);
+  assert.equal(detail.status, 'missing_cron');
+});
+
+test('local delivery with an origin delivery error is classified as stale warning', () => {
+  const repoDir = makeRepo();
+  fs.writeFileSync(path.join(repoDir, 'docs', 'workflows', 'definitions', 'delivery.yaml'), 'id: delivery\nname: Delivery\n');
+  fs.writeFileSync(path.join(repoDir, 'docs', 'workflows', 'runbooks', 'delivery.md'), '# Delivery\n');
+
+  const index = buildWorkflowIndex({
+    repoDir,
+    cronJobs: [{
+      id: 'delivery-job',
+      name: 'delivery',
+      status: 'active',
+      deliver: 'local',
+      lastDeliveryError: 'deliver=origin failed for old thread',
+    }],
+  });
+
+  assert.equal(index.workflows[0].status, 'stale_warning');
+});

--- a/test/workflows.test.js
+++ b/test/workflows.test.js
@@ -133,3 +133,50 @@ execution:
   assert.equal(index.workflows[0].workers[0].sessionId, 'codex-session-1');
   assert.equal(index.workflows[0].workers[1].status, 'waiting_approval');
 });
+
+test('buildWorkflowIndex overlays runtime worker status snapshots from repo-local files', () => {
+  const repoDir = makeRepo();
+  fs.mkdirSync(path.join(repoDir, 'reports', 'workflows', 'runtime'), { recursive: true });
+  fs.writeFileSync(path.join(repoDir, 'docs', 'workflows', 'definitions', 'runtime-workers.yaml'), `id: runtime-workers
+name: Runtime Workers
+execution:
+  worker_status_file: reports/workflows/runtime/runtime-workers.json
+  workers:
+    - id: codex-lane
+      label: Codex Lane
+      provider: codex
+      status: idle
+      session_id: old-session
+`);
+  fs.writeFileSync(path.join(repoDir, 'docs', 'workflows', 'runbooks', 'runtime-workers.md'), '# Runtime Workers\n');
+  fs.writeFileSync(path.join(repoDir, 'reports', 'workflows', 'runtime', 'runtime-workers.json'), JSON.stringify({
+    workers: [{
+      id: 'codex-lane',
+      status: 'blocked',
+      session_id: 'live-session-42',
+      updated_at: '2026-05-31T13:45:00+09:00',
+      note: 'approval required',
+    }, {
+      id: 'claude-review',
+      label: 'Claude Review',
+      provider: 'claude',
+      status: 'running',
+    }],
+  }));
+
+  const index = buildWorkflowIndex({ repoDir, cronJobs: [{ id: 'runtime-workers', name: 'runtime-workers', status: 'active' }] });
+  const workflow = index.workflows[0];
+
+  assert.equal(workflow.workers.length, 2);
+  assert.equal(workflow.workers[0].id, 'codex-lane');
+  assert.equal(workflow.workers[0].label, 'Codex Lane');
+  assert.equal(workflow.workers[0].provider, 'codex');
+  assert.equal(workflow.workers[0].status, 'waiting_approval');
+  assert.equal(workflow.workers[0].sessionId, 'live-session-42');
+  assert.equal(workflow.workers[0].note, 'approval required');
+  assert.equal(workflow.workers[1].id, 'claude-review');
+  assert.equal(workflow.workers[1].status, 'generating');
+  assert.equal(index.summary.workers.total, 2);
+  assert.equal(index.summary.workers.waiting_approval, 1);
+  assert.equal(index.summary.workers.generating, 1);
+});

--- a/test/workflows.test.js
+++ b/test/workflows.test.js
@@ -7,6 +7,7 @@ const test = require('node:test');
 const {
   buildWorkflowIndex,
   getWorkflowDetail,
+  normalizeWorkerStatus,
 } = require('../lib/workflows');
 
 function makeRepo() {
@@ -83,4 +84,52 @@ test('local delivery with an origin delivery error is classified as stale warnin
   });
 
   assert.equal(index.workflows[0].status, 'stale_warning');
+});
+
+test('normalizeWorkerStatus maps ADHDev-style worker states to the HCI status vocabulary', () => {
+  assert.equal(normalizeWorkerStatus('waiting_approval'), 'waiting_approval');
+  assert.equal(normalizeWorkerStatus('generating'), 'generating');
+  assert.equal(normalizeWorkerStatus('running'), 'generating');
+  assert.equal(normalizeWorkerStatus('complete'), 'idle');
+  assert.equal(normalizeWorkerStatus('blocked'), 'waiting_approval');
+  assert.equal(normalizeWorkerStatus('crashed'), 'error');
+  assert.equal(normalizeWorkerStatus(''), 'unknown');
+});
+
+test('buildWorkflowIndex exposes normalized worker session status and summary counts', () => {
+  const repoDir = makeRepo();
+  fs.writeFileSync(path.join(repoDir, 'docs', 'workflows', 'definitions', 'workers.yaml'), `id: workers
+name: Worker Status
+execution:
+  workers:
+    - id: codex-lane
+      label: Codex Lane
+      provider: codex
+      status: running
+      session_id: codex-session-1
+      updated_at: 2026-05-31T13:20:00+09:00
+    - id: claude-review
+      provider: claude
+      status: waiting_approval
+`);
+  fs.writeFileSync(path.join(repoDir, 'docs', 'workflows', 'runbooks', 'workers.md'), '# Workers\n');
+
+  const index = buildWorkflowIndex({ repoDir, cronJobs: [{ id: 'workers', name: 'workers', status: 'active' }] });
+
+  assert.deepEqual(index.summary.workers, {
+    total: 2,
+    starting: 0,
+    generating: 1,
+    waiting_approval: 1,
+    idle: 0,
+    error: 0,
+    stopped: 0,
+    unknown: 0,
+  });
+  assert.equal(index.workflows[0].workers[0].id, 'codex-lane');
+  assert.equal(index.workflows[0].workers[0].label, 'Codex Lane');
+  assert.equal(index.workflows[0].workers[0].provider, 'codex');
+  assert.equal(index.workflows[0].workers[0].status, 'generating');
+  assert.equal(index.workflows[0].workers[0].sessionId, 'codex-session-1');
+  assert.equal(index.workflows[0].workers[1].status, 'waiting_approval');
 });


### PR DESCRIPTION
## Summary
- Add read-only Mira workflow indexing from MiraRepo `docs/workflows/definitions`, runbooks, reports, and Hermes cron metadata.
- Add authenticated `/api/workflows` and `/api/workflows/:id` endpoints.
- Add a Workflows tab with summary cards, inventory table, status/warning display, and raw definition/runbook/report preview modal.
- Add node:test coverage for workflow indexing, detail loading, and stale delivery-warning classification.
- Make cron lookup LaunchAgent-safe by using direct Hermes CLI execution instead of shell `timeout` / PATH-dependent lookup on macOS.
- Synced with upstream `main` / v3.5.1 and resolved the `server.js` conflict.

## Safety notes
- Read-only MVP: no cron create/update/pause/resume, no file writes, no external posting.
- Auth is required for workflow API endpoints.
- Secrets are not parsed or displayed beyond the existing repo files selected by workflow definitions.
- MiraRepo path can be overridden with `MIRA_REPO_DIR`; defaults to local MiraRepo worktree candidates.

## Verification
- `npm test` — passed, 14/14 tests.
- `npm run build` — passed.
- `git diff --check` — passed.
- Local LaunchAgent smoke test at `http://127.0.0.1:10272`:
  - login API returned ok for existing admin session.
  - `/api/workflows` returned 3 workflows.
  - summary returned `ok=1`, `stale_warning=1`, `missing_cron=1`, `active_failure=0`.
  - `/api/workflows/weekly-memory-refactor` linked cron id `d27468bad831`, deliver `local`, and showed the expected stale delivery warning.
- GitHub reports this PR as mergeable after upstream sync.

Related: ZennAI-Japan/MiraRepo#42
