### PR TITLE
fix: set HERMES_HOME instead of HERMES_PROFILE for non-default profiles

### DIFF
--- a/lib/tui-gateway-bridge.js
+++ b/lib/tui-gateway-bridge.js
@@ -55,8 +55,14 @@ class TuiGatewayBridge {
     const delimiter = process.platform === 'win32' ? ';' : ':';
     env.PYTHONPATH = pyPath ? `${root}${delimiter}${pyPath}` : root;
 
-    // Profile-specific env
-    env.HERMES_PROFILE = this.profile === 'default' ? '' : this.profile;
+    // Profile-specific env — hermes_constants.get_hermes_home() reads HERMES_HOME,
+    // not HERMES_PROFILE. For non-default profiles HERMES_HOME must point to the
+    // profile subdirectory, otherwise all sessions land in the default profile.
+    if (this.profile && this.profile !== 'default') {
+      env.HERMES_HOME = path.join(os.homedir(), '.hermes', 'profiles', this.profile);
+    } else {
+      env.HERMES_HOME = path.join(os.homedir(), '.hermes');
+    }
 
     console.log(`[TUI:${this.profile}] spawning: ${python} -m tui_gateway.entry`);
 


### PR DESCRIPTION
## Problem

When selecting a non-default profile in the HCI chat sidebar, conversations were always saved to the **default profile** (`~/.hermes`) instead of the selected one.

The `TuiGatewayBridge` was setting `HERMES_PROFILE=<name>` in the spawned process environment, but `hermes_constants.get_hermes_home()` reads `HERMES_HOME`, not `HERMES_PROFILE`. Since `HERMES_HOME` was never set, Python always fell back to `~/.hermes` regardless of profile selection.

This is the cross-profile data corruption scenario described in [`hermes_constants.py` issue #18594](https://github.com/NousResearch/hermes-agent/issues/18594) — the code even contains a loud one-shot warning for exactly this case.

## Fix

Set `HERMES_HOME` to `~/.hermes/profiles/<name>` for non-default profiles (and explicitly to `~/.hermes` for the default), matching the convention used by the gateway systemd template and other subprocess spawners.

## Test plan

- [ ] Start HCI, select a non-default profile in the chat dropdown
- [ ] Send a message — confirm `[TUI:<profile>] spawning` log appears
- [ ] Check that the session appears under the correct profile in the sidebar
- [ ] Confirm sessions are written to `~/.hermes/profiles/<name>/state.db`, not `~/.hermes/state.db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)