### PR TITLE
fix: show captured streaming text when DB write lags behind chat.done

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1737,15 +1737,35 @@ function finalizeWsChat() {
   // in case the final message hadn't been written to DB yet.
   if (state._currentChatSession) {
     reloadCurrentSessionMessages().then(() => {
-      // Merge captured streaming text if the last assistant message has no body
+      // Merge captured streaming text if the DB didn't persist the response in time.
+      // chat.done fires before Hermes writes to SQLite, so two cases arise:
+      //   1. DB wrote an empty assistant entry → fill its body
+      //   2. DB hasn't written the response yet → last element is the user message → append a new assistant bubble
       if (capturedText) {
         const messagesDiv = document.getElementById('chat-messages');
         if (messagesDiv) {
-          const lastMsg = messagesDiv.querySelector('.msg-assistant:last-child');
-          const lastBody = lastMsg?.querySelector('.msg-body');
-          if (lastBody && !lastBody.textContent?.trim()) {
+          const lastAssistant = messagesDiv.querySelector('.msg-assistant:last-child');
+          const lastBody = lastAssistant?.querySelector('.msg-body');
+          if (lastAssistant && lastBody && !lastBody.textContent?.trim()) {
+            // Case 1: empty assistant entry in DB
             lastBody.innerHTML = renderChatContent(capturedText.substring(0, 8000));
             highlightCodeBlocks(lastBody);
+            messagesDiv.scrollTop = messagesDiv.scrollHeight;
+          } else if (!lastAssistant) {
+            // Case 2: response not in DB yet — show captured streaming text as a placeholder bubble
+            const div = document.createElement('div');
+            div.className = 'chat-msg msg-assistant';
+            const header = document.createElement('div');
+            header.className = 'msg-header';
+            header.innerHTML = '<span class="msg-header-label">🤖 Assistant</span>';
+            const body = document.createElement('div');
+            body.className = 'msg-body';
+            body.innerHTML = renderChatContent(capturedText.substring(0, 8000));
+            div.appendChild(header);
+            div.appendChild(body);
+            messagesDiv.appendChild(div);
+            highlightCodeBlocks(div);
+            messagesDiv.scrollTop = messagesDiv.scrollHeight;
           }
         }
       }


### PR DESCRIPTION
## Problem

When using the TUI Gateway chat, the assistant's response would visibly stream in, then **disappear** just before being displayed permanently. Only the previous messages remained visible. Clicking the session in the sidebar reloaded it correctly from the database.

### Root cause

`chat.done` fires before Hermes finishes writing the final message to SQLite. `finalizeWsChat()` captures the streamed text, removes the streaming element, then calls `reloadCurrentSessionMessages()` to rebuild the view from the DB.

The existing merge logic then tried to recover the captured text:

```js
const lastMsg = messagesDiv.querySelector('.msg-assistant:last-child');
const lastBody = lastMsg?.querySelector('.msg-body');
if (lastBody && !lastBody.textContent?.trim()) { ... }
```

This selector returns `null` when the DB hasn't written the new assistant message yet — the last element in the DOM is the **user** message, not an assistant bubble. The captured text was silently discarded.

## Fix

Add an `else if (!lastAssistant)` branch: when no assistant bubble is last in the DOM (meaning the DB hasn't persisted the response yet), create and append one from the captured streaming text.

Two cases are now handled:
1. DB wrote an empty assistant entry → fill its body (existing behaviour)
2. DB hasn't written the response yet → append a new placeholder bubble (new)

## Test plan

- [ ] Send a message via TUI Gateway chat
- [ ] Confirm the assistant response remains visible after streaming completes
- [ ] Confirm clicking the session in the sidebar shows the same content
- [ ] Test with a fast response (DB may have written in time) and a slow one

🤖 Generated with [Claude Code](https://claude.com/claude-code)