### PR TITLE
fix: nullify bridge.proc on exit to allow re-spawn on next chat.start

### DIFF
--- a/lib/tui-gateway-bridge.js
+++ b/lib/tui-gateway-bridge.js
@@ -127,6 +127,7 @@ class TuiGatewayBridge {
         this.readyTimer = null;
       }
       this.ready = false;
+      this.proc = null;
       console.log(`[TUI:${this.profile}] exited (${code})`);
       this._rejectPending(new Error(`gateway exited${code === null ? '' : ` (${code})`}`));
       this._broadcast({ type: 'tui.exit', code });
@@ -361,6 +362,7 @@ class TuiGatewayBridge {
     const configured = process.env.HERMES_PYTHON?.trim() || process.env.PYTHON?.trim();
     if (configured) return configured;
 
+    const fs = require('fs');
     const venv = process.env.VIRTUAL_ENV?.trim();
     const candidates = [
       venv && path.resolve(venv, 'bin/python'),
@@ -373,7 +375,7 @@ class TuiGatewayBridge {
       'python',
     ];
     for (const p of candidates) {
-      if (p) return p;
+      if (p && fs.existsSync(p)) return p;
     }
     return 'python3';
   }


### PR DESCRIPTION
## Problem

After a TUI Gateway chat session ends (process exits), starting a new chat fails with `'TUI gateway not ready'` on every subsequent attempt until HCI is restarted.

### Root cause

`server.js` guards against re-spawning with:

```js
if (!bridge.proc) {
  await bridge.start();
}
```

But `TuiGatewayBridge`'s exit handler only set `this.ready = false` — it never cleared `this.proc`. The stale `ChildProcess` reference (with `exitCode` set) caused the guard to skip `start()`, so `chatStart()` was called on a dead process and threw immediately.

## Fix

**1. Nullify `this.proc` in the exit handler** so the `!bridge.proc` guard in `server.js` correctly triggers a re-spawn on the next `chat.start`.

**2. Check `fs.existsSync()` on Python candidate paths** before returning them from `_resolvePython()`. Previously the first non-empty path string was returned even if the file didn't exist — this caused silent failures on macOS where venv paths may not exist.

## Test plan

- [ ] Start a chat via TUI Gateway, wait for it to complete
- [ ] Send another message in a new chat — confirm it connects successfully without restarting HCI
- [ ] Confirm `[TUI:default] spawning` appears in logs for the second chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)