### PR TITLE
fix: timestamp + spacing in chat and agent session views

### DIFF
--- a/src/css/chat.css
+++ b/src/css/chat.css
@@ -358,6 +358,9 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  /* Without an explicit gap, user bubbles (justify-content: flex-end) collapse
+     the label and the timestamp against each other, producing "You23:27". */
+  gap: 8px;
   margin-bottom: 4px;
   font-size: 9px;
   font-weight: 600;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -863,7 +863,15 @@ function renderChatMessage(msg) {
     system: { label: 'System', icon: '⚙️', cls: 'msg-system' },
   };
   const c = labels[role] || labels.system;
-  const ts = msg.timestamp ? new Date(msg.timestamp * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '';
+  // Include the date alongside the time so messages from older sessions are
+  // identifiable at a glance (the header used to show only HH:MM, which read
+  // as "today" regardless of the actual send date).
+  const ts = msg.timestamp
+    ? new Date(msg.timestamp * 1000).toLocaleString([], {
+        year: 'numeric', month: 'short', day: 'numeric',
+        hour: '2-digit', minute: '2-digit',
+      })
+    : '';
 
   const div = document.createElement('div');
   div.className = `chat-msg ${c.cls}`;
@@ -3203,7 +3211,17 @@ async function toggleSessionDetail(btn, sessionId, profile) {
         system: { bg: 'rgba(156,163,175,0.08)', border: '#9ca3af' },
       };
       const rc = roleColors[m.role] || roleColors.system;
-      const ts = m.timestamp ? new Date(m.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '';
+      // Hermes stores message.timestamp as Unix epoch *seconds* (matches
+      // renderChatMessage in the chat panel). Without *1000 every row
+      // rendered the same epoch-1970 time (~15:18 in CET) instead of the
+      // real send time. Also include the date so the panel is useful for
+      // sessions older than today.
+      const ts = m.timestamp
+        ? new Date(m.timestamp * 1000).toLocaleString([], {
+            year: 'numeric', month: 'short', day: 'numeric',
+            hour: '2-digit', minute: '2-digit',
+          })
+        : '';
       let content = toDisplayText(m.content);
       content = content.replace(/Resume this session with:.*$/gm, '');
       content = content.replace(/^Session:\s*\d+.*$/gm, '');


### PR DESCRIPTION
## Summary

Two related rendering bugs in the message-header layout:

- **Agent → Sessions → 👁** (`toggleSessionDetail`) called `new Date(m.timestamp)` without the `* 1000` multiplier that the chat panel already uses. Hermes stores timestamps as Unix epoch *seconds*; interpreted as milliseconds they all land in January 1970, so every row rendered the same time (e.g. **15:18** in CET) regardless of when the message was actually sent.
- **Chat bubbles** for the user role override `.msg-header` with `justify-content: flex-end`. With no `gap`, the label flex item butts straight against the timestamp flex item, producing **"You23:27"** / **"Assistant23:27"** with no separator.

Both headers are also expanded to show the **date** (year/month/day) alongside the time so messages from older sessions are identifiable at a glance.

## Changes

- `src/js/main.js` — `toggleSessionDetail` now multiplies the timestamp by 1000, matching `renderChatMessage`. Both formatters use `toLocaleString` with date + time fields.
- `src/css/chat.css` — `.msg-header` gets `gap: 8px` so the label/time never collapse against each other, no matter what `justify-content` the per-role override sets.

## Test plan

- [ ] Open any chat session → header shows `👤 You · 24 May 2026, 23:27` (or similar locale-appropriate format) instead of `You23:27`
- [ ] Open Agent → pick a profile → Sessions → click 👁 on any row → message timestamps reflect the actual send date and time, not `15:18` every line
- [ ] User and assistant bubbles both have visible spacing between label and timestamp
- [ ] Verify under a non-en locale that `toLocaleString` formats sensibly

🤖 Generated with [Claude Code](https://claude.com/claude-code)