### PR TITLE
fix(chat): bootstrap TUI bridge on demand for chat.send + detach on profile switch

### DIFF
--- a/server.js
+++ b/server.js
@@ -6239,14 +6239,45 @@ wss.on('connection', async (socket, req) => {
         }
       }
       if (msg.type === 'chat.stop' && socket.authed && socket.tuiBridge) {
-        socket.tuiBridge.chatStop(socket.tuiSessionId);
+        socket.tuiBridge.chatStop(msg.session_id || socket.tuiSessionId);
       }
-      if (msg.type === 'chat.send' && socket.authed && socket.tuiBridge) {
+      if (msg.type === 'chat.send' && socket.authed) {
         try {
-          // Use frontend's session_id if provided, else fall back to chat.start session
-          const sid = msg.session_id || socket.tuiSessionId;
-          if (msg.session_id) socket.tuiSessionId = msg.session_id; // update for future sends
-          await socket.tuiBridge.chatSend({ message: msg.message, session_id: sid });
+          if (!socket.tuiBridge) {
+            const profileName = msg.profile || 'default';
+            console.log(`[WS] chat.send bootstrapping bridge profile="${profileName}" session_id="${msg.session_id || 'null'}"`);
+            const bridge = getBridge(profileName);
+            if (!bridge.proc) {
+              let startErr = null;
+              for (let attempt = 1; attempt <= 3; attempt++) {
+                try {
+                  await bridge.start();
+                  startErr = null;
+                  break;
+                } catch (e) {
+                  startErr = e;
+                  console.error(`[WS] Bridge start attempt ${attempt}/3 failed:`, e.message);
+                  if (attempt < 3) await new Promise(r => setTimeout(r, 500));
+                }
+              }
+              if (startErr) {
+                socket.send(JSON.stringify({ type: 'chat.error', error: 'TUI gateway unavailable after 3 retries.' }));
+                return;
+              }
+            }
+            bridge.addClient(socket);
+            socket.tuiBridge = bridge;
+          }
+          if (msg.session_id && msg.session_id !== socket.tuiSessionId) {
+            const result = await socket.tuiBridge.chatStart({
+              message: msg.message,
+              session_id: msg.session_id,
+            });
+            socket.tuiSessionId = result.session_id;
+          } else {
+            const sid = msg.session_id || socket.tuiSessionId;
+            await socket.tuiBridge.chatSend({ message: msg.message, session_id: sid });
+          }
         } catch (err) {
           socket.send(JSON.stringify({ type: 'chat.error', error: err.message }));
         }

--- a/server.js
+++ b/server.js
@@ -6208,7 +6208,13 @@ wss.on('connection', async (socket, req) => {
       // ── Chat via WebSocket (TUI Gateway) ──
       if (msg.type === 'chat.start' && socket.authed) {
         console.log(`[WS] chat.start received profile="${msg.profile || 'default'}" session_id="${msg.session_id || 'null'}"`);
-        const bridge = getBridge(msg.profile || 'default');
+        const profileName = msg.profile || 'default';
+        if (socket.tuiBridge && socket.tuiBridge.profile !== profileName) {
+          socket.tuiBridge.removeClient(socket);
+          socket.tuiBridge = null;
+          socket.tuiSessionId = undefined;
+        }
+        const bridge = getBridge(profileName);
         if (!bridge.proc) {
           let startErr = null;
           for (let attempt = 1; attempt <= 3; attempt++) {
@@ -6243,8 +6249,13 @@ wss.on('connection', async (socket, req) => {
       }
       if (msg.type === 'chat.send' && socket.authed) {
         try {
+          const profileName = msg.profile || 'default';
+          if (socket.tuiBridge && socket.tuiBridge.profile !== profileName) {
+            socket.tuiBridge.removeClient(socket);
+            socket.tuiBridge = null;
+            socket.tuiSessionId = undefined;
+          }
           if (!socket.tuiBridge) {
-            const profileName = msg.profile || 'default';
             console.log(`[WS] chat.send bootstrapping bridge profile="${profileName}" session_id="${msg.session_id || 'null'}"`);
             const bridge = getBridge(profileName);
             if (!bridge.proc) {

--- a/src/js/chat/websocket.js
+++ b/src/js/chat/websocket.js
@@ -48,7 +48,7 @@ async function sendViaWebSocket(text, profile, sessionId) {
     // Send via WS — use chatStart for first message, chatSend for subsequent
     let ok;
     if (sessionId) {
-      ok = wsClient.chatSend({ message: text, session_id: sessionId });
+      ok = wsClient.chatSend({ message: text, session_id: sessionId, profile });
     } else {
       ok = wsClient.chatStart({ message: text, profile, session_id: sessionId });
     }

--- a/src/js/ws-client.js
+++ b/src/js/ws-client.js
@@ -89,8 +89,8 @@ class HciWsClient extends EventTarget {
   chatStart({ message, profile, session_id, model }) {
     return this.send({ type: 'chat.start', message, profile, session_id, model });
   }
-  chatSend({ message, session_id }) {
-    return this.send({ type: 'chat.send', message, session_id });
+  chatSend({ message, session_id, profile }) {
+    return this.send({ type: 'chat.send', message, session_id, profile });
   }
   chatStop() {
     return this.send({ type: 'chat.stop' });


### PR DESCRIPTION
Two related fixes for the WebSocket chat path, both surfaced by the same
test sequence.

## Bug A — `chat.send` silently drops when the WS connection hasn't seen `chat.start` yet

Repro:
1. Restart `node server.js` (cold WS connection, `socket.tuiBridge === null`)
2. Open HCI, **without sending a new chat first**, click an existing session in the sidebar
3. Send a message

Expected: message routes to the gateway, response streams back.
Actual: nothing happens. User bubble + blinking cursor, but no response, ever. Stop button is also dead.

Cause: PR #68 (1419564) introduced `chat.send` as a lightweight follow-up to `chat.start`. The handler is gated on `socket.tuiBridge`. The frontend (`sendViaWebSocket`) uses `wsClient.chatSend` whenever `session_id` is set — including the *first* message of a session opened directly from the sidebar. With no prior `chat.start`, `socket.tuiBridge === null`, the guard short-circuits, and the message is dropped server-side with no acknowledgement.

Fix: drop the `&& socket.tuiBridge` gate, bootstrap the bridge in-place (same retry loop `chat.start` uses), and when `msg.session_id !== socket.tuiSessionId` route through `bridge.chatStart` so the gateway runs `session.resume` + `prompt.submit` (the lightweight `bridge.chatSend` can only target sessions already mapped in `_sidMap`).

Frontend changes (`ws-client.js`, `chat/websocket.js`) pass `profile` on `chat.send` so the server knows which gateway port to bootstrap.

## Bug B — switching profile mid-session spawns a new thread in the wrong profile

Repro (with Bug A fix applied, otherwise can't get this far):
1. Open HCI on profile `default`, start a chat
2. Switch chat-profile dropdown to a non-default profile (e.g. `tomek`)
3. Click one of its existing sessions in the sidebar
4. Send a message

Expected: response streams in the clicked session.
Actual: response arrives, but a **new entry** appears in the `default` profile's session list. Subsequent messages keep spawning fresh threads in `default`.

Server log shows the smoking gun:
```
[TUI:default] session.resume(20260603_180322_d0f300)
[TUI:default] session.resume FAILED (session not found), creating new session
```

Cause: `chat.start` binds the socket to profile A's bridge subprocess. Switching the dropdown to B and clicking a B-session sends `chat.send` with `msg.profile = "B"`, but `socket.tuiBridge` is still A. The session_id lookup happens in A's DB, fails, and the bridge's auto-resume fallback in `chatStart` silently spawns a new session via `session.create` → new thread in A.

Fix: on both `chat.start` and `chat.send`, when `socket.tuiBridge.profile !== msg.profile`, `removeClient` and null out the binding so the next `getBridge` / bootstrap routes through the right subprocess.

## Commits

1. `fix(chat): bootstrap TUI bridge on demand for chat.send` — Bug A
2. `fix(chat): detach prior bridge when WS sees a profile switch` — Bug B

## Verified

Tested locally on top of `main` (`204e0e5`, v3.6.0): both repros eliminated, normal chat flow unaffected. Two separate commits so each fix can be reviewed in isolation.