### PR TITLE
fix(chat): preserve session title against i18n MutationObserver overwrite

### DIFF
--- a/src/js/chat/core.js
+++ b/src/js/chat/core.js
@@ -482,6 +482,7 @@ async function loadChatSession(sessionId, offset = 0) {
     const data = await r.json();
     if (titleEl) {
       titleEl.textContent = toDisplayText(resolveSessionDisplayTitle({ sessionId, data }));
+      titleEl.removeAttribute('data-i18n');
     }
     if (subtitleEl) subtitleEl.textContent = `${data.messages?.length || 0} messages · ${profile}`;
 
@@ -658,7 +659,10 @@ function newChatSession() {
 
   // Reset UI
   const titleEl = document.getElementById('chat-title');
-  if (titleEl) titleEl.textContent = t('ui.newChat');
+  if (titleEl) {
+    titleEl.setAttribute('data-i18n', 'auto.newChat2');
+    titleEl.textContent = t('ui.newChat');
+  }
   const subtitleEl = document.getElementById('chat-subtitle');
   if (subtitleEl) subtitleEl.textContent = '';
   const statusSessionEl = document.getElementById('chat-status-session');
@@ -774,7 +778,15 @@ async function renameChatSession(sessionId = 0) {
   try {
     const profile = document.getElementById('chat-profile')?.value || 'default';
     const r = await fetch(`/api/sessions/${encodeURIComponent(sid)}/rename`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': state.csrfToken || '' }, body: JSON.stringify({ title: n, profile }), credentials: 'include' });
-    if (r.ok) { showToast(t('toast.sessionRenamed'), 'success'); document.getElementById('chat-title').textContent = n; refreshChatSidebar(); } else showToast(t('toast.renameFailed'), 'error');
+    if (r.ok) {
+      showToast(t('toast.sessionRenamed'), 'success');
+      const renamed = document.getElementById('chat-title');
+      if (renamed) {
+        renamed.textContent = n;
+        renamed.removeAttribute('data-i18n');
+      }
+      refreshChatSidebar();
+    } else showToast(t('toast.renameFailed'), 'error');
   } catch (e) { showToast(t('toast.renameFailedPrefix') + e.message, 'error'); }
 }
 
@@ -804,14 +816,20 @@ function updateChatHeader() {
   const subtitleEl = document.getElementById('chat-subtitle');
   const profile = document.getElementById('chat-profile')?.value || 'default';
   if (!sid) {
-    if (titleEl) titleEl.textContent = t('ui.newChat');
+    if (titleEl) {
+      titleEl.setAttribute('data-i18n', 'auto.newChat2');
+      titleEl.textContent = t('ui.newChat');
+    }
     if (subtitleEl) subtitleEl.textContent = profile !== 'default' ? `Profile: ${profile}` : '';
     return;
   }
   // Find session title from sidebar
   const item = document.querySelector(`.chat-session-item[data-sid="${sid}"]`);
   const sidebarTitle = item?.dataset?.title || '';
-  if (titleEl) titleEl.textContent = sidebarTitle || sid.substring(0, 20) + '...';
+  if (titleEl) {
+    titleEl.textContent = sidebarTitle || sid.substring(0, 20) + '...';
+    titleEl.removeAttribute('data-i18n');
+  }
   if (subtitleEl) subtitleEl.textContent = `${profile !== 'default' ? profile + ' · ' : ''}${sid.substring(0, 16)}`;
 }
 


### PR DESCRIPTION
## Symptom

Click any historical session in the sidebar. The chat header briefly shows the saved title (e.g. "Polish Hello to Tomek"), then **instantly flips back to "New Chat"**. Sending a message in that session works correctly (it routes to the right session), but the header stays stuck on "New Chat".

Affects every loaded session, every time. Also affects rename — typing a new title via the rename modal flashes the new value and reverts.

## Root cause

`<div class="chat-title" id="chat-title" data-i18n="auto.newChat2">New Chat</div>` carries the `data-i18n` attribute. `main.js` installs a debounced `MutationObserver` that runs `applyTranslations()` on any DOM mutation — and `applyTranslations` reads `data-i18n` and overwrites `textContent` to the localized value of `auto.newChat2`.

Flow:

1. `loadChatSession()` sets `titleEl.textContent = sessionTitle` ✓
2. Mutation observer fires from the textContent change
3. `applyTranslations()` finds `data-i18n="auto.newChat2"` still on the element
4. It overwrites `textContent` back to "New Chat"

The session title is correct in memory (`state._currentChatSession`) and in the DB — only the header display is wrong.

## Fix

Four sites need to manage `data-i18n` when changing the title:

| Site | Action |
|---|---|
| `loadChatSession` — bind session title | `removeAttribute('data-i18n')` after setting textContent |
| `newChatSession` — reset to "New Chat" | `setAttribute('data-i18n', 'auto.newChat2')` so future locale switches still pick it up |
| Rename flow (`renameChatSession`) | `removeAttribute('data-i18n')` after setting new title |
| `updateChatHeader` | both branches — remove attr in the has-sid branch, restore in the no-sid branch |

After the fix, the observer still runs but only finds `data-i18n` when the title is genuinely the i18n-managed "New Chat" placeholder. Real session titles are immune.

## Test plan

- [ ] Click a historical session in the sidebar → its title shows and stays
- [ ] Click "+ New Chat" → header reverts to "New Chat"
- [ ] Switch UI language (Polish ↔ English) on a New Chat → label re-translates
- [ ] Switch UI language while a real session is open → its title does **not** get clobbered
- [ ] Rename a session via the modal → new title sticks, no flash-back

## Verified

Tested on top of `main` (`204e0e5`, v3.6.0). Deterministic repro before, gone after.