### PR TITLE
fix(chat): collapse tool result by default (consistent with reasoning)

### DIFF
--- a/src/js/chat/core.js
+++ b/src/js/chat/core.js
@@ -610,10 +610,9 @@ function renderChatMessage(msg) {
     }
   }
 
-  // Tool result content
+  // Tool result content — collapsed by default for consistency with the
+  // reasoning panel below; long tool outputs otherwise dominate the chat.
   if (role === 'tool') {
-    const contentDiv = document.createElement('div');
-    contentDiv.className = 'msg-tool-result';
     let content = msg.content;
     try {
       const parsed = JSON.parse(content);
@@ -621,8 +620,22 @@ function renderChatMessage(msg) {
       else if (parsed.results) content = JSON.stringify(parsed.results, null, 2);
       else content = JSON.stringify(parsed, null, 2);
     } catch {}
-    contentDiv.textContent = toDisplayText(content).substring(0, 2000);
-    div.appendChild(contentDiv);
+    const text = toDisplayText(content).substring(0, 2000);
+    const firstLine = text.split('\n')[0].slice(0, 120);
+    const details = document.createElement('details');
+    details.style.cssText = 'margin-top:4px;';
+    const summary = document.createElement('summary');
+    summary.style.cssText = 'cursor:pointer;font-size:11px;color:var(--fg-subtle);';
+    const labelText = msg.tool_name ? `⚡ ${msg.tool_name}` : '⚡ Tool Result';
+    const preview = firstLine ? ` — ${firstLine}${text.length > firstLine.length ? '…' : ''}` : '';
+    summary.textContent = labelText + preview;
+    const body = document.createElement('div');
+    body.className = 'msg-tool-result';
+    body.style.cssText = 'margin-top:4px;';
+    body.textContent = text;
+    details.appendChild(summary);
+    details.appendChild(body);
+    div.appendChild(details);
     return div;
   }
 


### PR DESCRIPTION
## Symptom

Inconsistency in how `renderChatMessage` (in `src/js/chat/core.js`) displays auxiliary content:

| Section | Default state | Wrapping |
|---|---|---|
| `msg.reasoning` | **collapsed** | inside `<details>` with a summary |
| `role === 'tool'` content | **expanded** | rendered directly in a `<div>` |

Tool results often span hundreds of lines (file listings, JSON blobs, shell output), so the chat scroll becomes dominated by raw tool output rather than the conversation. Reasoning sections behave correctly — click summary to expand. Tool results should match that pattern.

## Fix

Wrap the `role === 'tool'` branch in a `<details>` with the same summary pattern used by reasoning. Summary shows a compact label so users can identify the tool at a glance:

- With `msg.tool_name` present: `⚡ <tool_name> — <first line preview>…`
- Without: `⚡ Tool Result — <first line preview>…`

Body is the same content that used to render directly, now collapsed inside the `<details>`.

## Test plan

- [ ] Load a chat session with several tool calls
- [ ] Each tool message renders as a one-line collapsible summary
- [ ] Click summary → tool output expands as before
- [ ] Reasoning panels still collapsed by default (unchanged)
- [ ] User/assistant messages unchanged
- [ ] Long tool output no longer dominates the chat scroll

## Verified

Tested on top of `main` (`204e0e5`, v3.6.0). UX matches reasoning panel — chat is much more readable in sessions heavy on tool use.