### PR TITLE
Added workspace section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A self-hosted web dashboard for the [Hermes AI agent](https://github.com/NousResearch/hermes-agent) stack. Manage agents, chat, terminals, files, cron, token analytics, MCP servers, and swarm pipelines — behind a password gate.
 
+**Forked from [xaspx/hermes-control-interface](https://github.com/xaspx/hermes-control-interface)** with workspace enhancements — resizable file tree, editor, and chat panels.
+
 **Stack:** Vanilla JS + Vite · Node.js · Express · WebSocket · xterm.js · Chart.js · better-sqlite3  
 **Version:** 3.6.0 · **License:** MIT
 
@@ -10,11 +12,11 @@ A self-hosted web dashboard for the [Hermes AI agent](https://github.com/NousRes
 ## Quick Start
 
 ```bash
-git clone https://github.com/xaspx/hermes-control-interface.git
+git clone https://github.com/deepatel70/hermes-control-interface.git
 cd hermes-control-interface
 cp .env.example .env     # set HERMES_CONTROL_PASSWORD + HERMES_CONTROL_SECRET
 npm install && npm run build
-node server.js            # → http://localhost:10274
+node server.js            # → https://localhost:10272
 ```
 
 See [docs/INSTALL.md](docs/INSTALL.md) for production setup, nginx, and systemd.
@@ -26,7 +28,8 @@ See [docs/INSTALL.md](docs/INSTALL.md) for production setup, nginx, and systemd.
 | Page | What |
 |------|------|
 | **Home** | System health, agent overview, gateway status, token usage |
-| **Chat** | Real-time streaming via gateway API, tool call cards, multi-profile |
+| **Chat** | Real-time streaming, tool call cards, multi-profile |
+| **Workspace** | Browse, edit files and chat with Hermes scoped to a project directory |
 | **Agents** | Profile CRUD, gateway lifecycle, per-agent dashboard/sessions/cron |
 | **Office** | 3-panel swarm monitor — agent health, kanban pipeline, live feed |
 | **Monitor** | Gateway logs, CPU/RAM metrics, live process view |
@@ -160,7 +163,7 @@ Full config: [docs/CONFIG.md](docs/CONFIG.md)
 ## Updating
 
 ```bash
-git pull origin main
+git pull upstream main
 npm install
 npm run build
 # Restart your HCI service (adjust service name):
@@ -186,7 +189,7 @@ See [docs/DEPLOY.md](docs/DEPLOY.md) for zero-downtime deploys.
 ---
 
 Built for the [Hermes Agent](https://github.com/NousResearch/hermes-agent) ecosystem.  
-[@bayendor](https://x.com/bayendor) · [GitHub](https://github.com/xaspx/hermes-control-interface)
+Fork by [deepatel70](https://github.com/deepatel70) · Upstream [@bayendor](https://x.com/bayendor) · [GitHub](https://github.com/xaspx/hermes-control-interface)
 
 ---
 
@@ -201,9 +204,10 @@ HCI is a **self-hosted web dashboard** for the Hermes AI agent stack. Manage age
 **Q: What can I manage with HCI?**
 
 | Page | Capabilities |
-|---|---|
+|---|---|---|
 | **Home** | System health, agent overview, gateway status, token usage |
 | **Chat** | Real-time streaming, tool call cards, multi-profile |
+| **Workspace** | Browse, edit files and chat with Hermes scoped to a project directory |
 | **Agents** | Profile CRUD, gateway lifecycle, dashboard/sessions/cron |
 | **Office** | 3-panel swarm monitor — agent health, kanban, live feed |
 | **Monitor** | Gateway logs, CPU/RAM metrics, live process view |
@@ -249,14 +253,14 @@ Full operational control plane for MCP servers:
 **Q: How do I install HCI?**
 
 ```bash
-git clone https://github.com/xaspx/hermes-control-interface.git
+git clone https://github.com/deepatel70/hermes-control-interface.git
 cd hermes-control-interface
 cp .env.example .env     # set HERMES_CONTROL_PASSWORD + HERMES_CONTROL_SECRET
 npm install && npm run build
-node server.js            # → http://localhost:10274
+node server.js            # → https://localhost:10272
 ```
 
-See [docs/INSTALL.md](docs/INSTALL.md) for production setup.
+See [docs/INSTALL.md](docs/INSTALL.md) for full setup.
 
 **Q: What are the requirements?**
 
@@ -267,7 +271,7 @@ See [docs/INSTALL.md](docs/INSTALL.md) for production setup.
 **Q: How do I update HCI?**
 
 ```bash
-git pull origin main
+git pull upstream main
 npm install
 npm run build
 # Restart your HCI service (adjust service name):
@@ -381,7 +385,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for details.
 
 | Resource | Link |
 |---|---|
-| **GitHub Issues** | [github.com/xaspx/hermes-control-interface/issues](https://github.com/xaspx/hermes-control-interface/issues) |
+| **GitHub Issues** | [github.com/deepatel70/hermes-control-interface/issues](https://github.com/deepatel70/hermes-control-interface/issues) |
 | **Twitter** | [@bayendor](https://x.com/bayendor) |
 | **Hermes Agent** | [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) |
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/styles/github-dark.min.css" crossorigin="anonymous">
-  <script type="module" crossorigin src="/assets/index-CMwCQXu3.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-Dw-PwATl.css">
+  <script type="module" crossorigin src="/assets/index--142INFl.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-DBcH9-mv.css">
 </head>
 <body>
   <div id="login-overlay" class="overlay">
@@ -53,6 +53,7 @@
         <a href="#usage" class="nav-link" data-page="usage" data-i18n="topbar.usage">Usage</a>
         <a href="#logs" class="nav-link" data-page="logs" data-i18n="topbar.logs">Logs</a>
         <a href="#skills" class="nav-link" data-page="skills" data-i18n="topbar.skills">Skills</a>
+        <a href="#workspace" class="nav-link" data-page="workspace" data-i18n="topbar.workspace">Workspace</a>
         <a href="#files" class="nav-link" data-page="files" data-i18n="topbar.files">Files</a>
         <a href="#mcp" class="nav-link" data-page="mcp" data-i18n="topbar.mcp">MCP</a>
         <a href="#maintenance" class="nav-link" data-page="maintenance" data-i18n="topbar.maintenance">Maintenance</a>
@@ -101,6 +102,7 @@
       <div id="page-logs" class="page"></div>
       <div id="page-maintenance" class="page"></div>
       <div id="page-files" class="page"></div>
+      <div id="page-workspace" class="page"></div>
       <div id="page-office" class="page"></div>
       <div id="page-mcp" class="page"></div>
     </main>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-control-interface",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-control-interface",
-      "version": "3.5.1",
+      "version": "3.6.0",
       "hasInstallScript": true,
       "dependencies": {
         "@pydantic/genai-prices": "^0.0.56",

--- a/server.js
+++ b/server.js
@@ -542,13 +542,20 @@ app.post('/api/gateway/responses', requireAuth, requirePerm('chat.use'), async (
 });
 
 app.post('/api/chat/send', requireAuth, requirePerm('chat.use'), chatLimiter, async (req, res) => {
-  const { message, profile, sessionId, model } = req.body || {};
+  const { message, profile, sessionId, model, workspace } = req.body || {};
   if (!message || typeof message !== 'string') return res.status(400).json({ error: 'message required' });
 
   const prof = sanitizeProfileName(profile) || 'default';
 
+  // Prepend workspace context if provided
+  let chatMessage = message;
+  if (workspace && typeof workspace === 'string' && workspace.trim()) {
+    const resolvedWs = workspace.replace(/^~/, os.homedir());
+    chatMessage = `[WORKSPACE: ${resolvedWs}] Work in the directory: ${resolvedWs}. You have full access to read, write, search, and run commands in this project folder.\n\n${message}`;
+  }
+
   // Build hermes command
-  const escapedMsg = "'" + message.replace(/'/g, "'\\''") + "'";
+  const escapedMsg = "'" + chatMessage.replace(/'/g, "'\\''") + "'";
   const profileFlag = prof !== 'default' ? `-p ${prof}` : '';
   const modelFlag = model ? `-m ${model}` : '';
   // Resume existing session, or create new with empty --continue flag
@@ -2880,6 +2887,134 @@ app.get('/api/files/list', requireAuth, (req, res) => {
     });
   } catch (error) {
     res.status(500).json({ error: error.message || 'failed to list directory' });
+  }
+});
+
+// ── Workspace API ──────────────────────────────────────────────────────────
+// Persistent workspace directory for the workspace page
+
+const WORKSPACE_STORE = path.join(CONTROL_HOME, 'workspace.json');
+
+function loadWorkspace() {
+  try {
+    if (fs.existsSync(WORKSPACE_STORE)) {
+      return JSON.parse(fs.readFileSync(WORKSPACE_STORE, 'utf8'));
+    }
+  } catch {}
+  return { path: '' };
+}
+
+function saveWorkspace(data) {
+  try {
+    if (!fs.existsSync(CONTROL_HOME)) fs.mkdirSync(CONTROL_HOME, { recursive: true });
+    fs.writeFileSync(WORKSPACE_STORE, JSON.stringify(data, null, 2), 'utf8');
+  } catch (e) {
+    log('workspace.saveError', e.message);
+  }
+}
+
+app.get('/api/workspace', requireAuth, (req, res) => {
+  const ws = loadWorkspace();
+  const listDir = String(req.query.listDir || '');
+  let files = null;
+
+  if (listDir && ws.path) {
+    const baseDir = path.resolve(ws.path);
+    try {
+      if (!fs.existsSync(baseDir) || !fs.statSync(baseDir).isDirectory()) {
+        files = { error: 'workspace directory does not exist or is not a directory' };
+      } else {
+        const dirPath = listDir === '/' ? baseDir : path.resolve(baseDir, listDir.replace(/^\/+/, ''));
+        if (!dirPath.startsWith(baseDir)) {
+          files = { error: 'path outside workspace' };
+        } else if (!fs.existsSync(dirPath) || !fs.statSync(dirPath).isDirectory()) {
+          files = { error: 'not a directory' };
+        } else {
+          const items = fs.readdirSync(dirPath).map(name => {
+            try {
+              const itemPath = path.join(dirPath, name);
+              const stat = fs.statSync(itemPath);
+              return { name, type: stat.isDirectory() ? 'directory' : 'file', size: stat.size, modified: stat.mtime.toISOString() };
+            } catch { return { name, type: 'unknown' }; }
+          });
+          items.sort((a, b) => {
+            if (a.type === 'directory' && b.type !== 'directory') return -1;
+            if (a.type !== 'directory' && b.type === 'directory') return 1;
+            return a.name.localeCompare(b.name);
+          });
+          files = { items, currentDir: listDir, parent: listDir === '/' ? null : path.dirname(listDir) };
+        }
+      }
+    } catch (e) {
+      files = { error: e.message };
+    }
+  }
+
+  res.json({ ok: true, path: ws.path, files });
+});
+
+app.post('/api/workspace', requireAuth, requireCsrf, (req, res) => {
+  const { path: wsPath } = req.body || {};
+  if (!wsPath || typeof wsPath !== 'string') {
+    return res.status(400).json({ error: 'path required' });
+  }
+  const resolved = path.resolve(wsPath.replace(/^~/, os.homedir()));
+  if (!fs.existsSync(resolved)) {
+    return res.status(400).json({ error: 'directory does not exist' });
+  }
+  if (!fs.statSync(resolved).isDirectory()) {
+    return res.status(400).json({ error: 'not a directory' });
+  }
+  saveWorkspace({ path: resolved });
+  log('workspace.set', resolved);
+  res.json({ ok: true, path: resolved });
+});
+
+// ── Workspace File Read/Write ──────────────────────────────────────────
+
+app.get('/api/workspace/file', requireAuth, (req, res) => {
+  const ws = loadWorkspace();
+  if (!ws.path) return res.status(400).json({ error: 'no workspace set' });
+
+  const requested = String(req.query.path || '');
+  if (!requested) return res.status(400).json({ error: 'path required' });
+
+  const baseDir = path.resolve(ws.path);
+  const absPath = path.resolve(baseDir, requested.replace(/^\/+/, ''));
+  if (!absPath.startsWith(baseDir)) return res.status(403).json({ error: 'path outside workspace' });
+
+  try {
+    if (!fs.existsSync(absPath)) return res.status(404).json({ error: 'file not found' });
+    if (fs.statSync(absPath).isDirectory()) return res.status(400).json({ error: 'is a directory' });
+
+    const content = fs.readFileSync(absPath, 'utf8');
+    res.json({ ok: true, path: requested, content });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+app.post('/api/workspace/file', requireAuth, requireCsrf, (req, res) => {
+  const ws = loadWorkspace();
+  if (!ws.path) return res.status(400).json({ error: 'no workspace set' });
+
+  const { path: requested, content } = req.body || {};
+  if (!requested) return res.status(400).json({ error: 'path required' });
+  if (content === undefined) return res.status(400).json({ error: 'content required' });
+
+  const baseDir = path.resolve(ws.path);
+  const absPath = path.resolve(baseDir, requested.replace(/^\/+/, ''));
+  if (!absPath.startsWith(baseDir)) return res.status(403).json({ error: 'path outside workspace' });
+
+  try {
+    // Ensure parent directory exists
+    const parentDir = path.dirname(absPath);
+    if (!fs.existsSync(parentDir)) fs.mkdirSync(parentDir, { recursive: true });
+    fs.writeFileSync(absPath, content, 'utf8');
+    log('workspace.fileSaved', requested);
+    res.json({ ok: true, path: requested });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
   }
 });
 

--- a/src/css/components.css
+++ b/src/css/components.css
@@ -1923,3 +1923,416 @@
   color: var(--coral);
   padding: 2px 0;
 }
+
+/* ── Workspace Page ─────────────────────────── */
+.workspace-layout {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 56px - 48px);
+  margin: -24px;
+  overflow: hidden;
+}
+
+.workspace-header {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-raised);
+  flex-shrink: 0;
+}
+
+.workspace-path-bar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.workspace-path-input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  outline: none;
+}
+
+.workspace-path-input:focus {
+  border-color: var(--primary);
+}
+
+.workspace-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  font-size: 12px;
+}
+
+.workspace-badge {
+  background: var(--primary);
+  color: var(--text-on-primary);
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-weight: 600;
+  font-size: 11px;
+}
+
+.workspace-path-text {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.workspace-path-text.muted {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.workspace-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.workspace-files-panel {
+  width: var(--ws-files-width, 280px);
+  min-width: 120px;
+  max-width: 50%;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-base);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.workspace-files-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-raised);
+  flex-shrink: 0;
+}
+
+.workspace-files-title {
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-file-tree {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.workspace-file-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text);
+  transition: background 0.15s;
+}
+
+.workspace-file-item:hover {
+  background: var(--bg-hover);
+}
+
+.workspace-file-item.dir {
+  font-weight: 500;
+}
+
+.workspace-file-item .file-icon {
+  flex-shrink: 0;
+  font-size: 14px;
+  width: 18px;
+  text-align: center;
+}
+
+.workspace-file-item .file-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-empty {
+  padding: 16px;
+  color: var(--text-muted);
+  text-align: center;
+  font-size: 13px;
+}
+
+/* ── File Editor ────────────────────────────── */
+.workspace-editor-panel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 200px;
+  overflow: hidden;
+  resize: horizontal;
+}
+
+.workspace-editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  background: var(--bg-raised);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.workspace-editor-filename {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-editor-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.workspace-editor-status {
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.workspace-editor-status.clean {
+  color: var(--success);
+}
+
+.workspace-editor-status.dirty {
+  color: var(--warning);
+  font-weight: 600;
+}
+
+.workspace-editor-textarea {
+  flex: 1;
+  width: 100%;
+  border: none;
+  outline: none;
+  resize: none;
+  background: var(--bg-base);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.5;
+  padding: 12px;
+  tab-size: 2;
+  overflow: auto;
+  min-height: 150px;
+}
+
+.workspace-editor-textarea:focus {
+  background: var(--bg);
+}
+
+/* ── Chat Panel ─────────────────────────────── */
+.workspace-chat-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+.workspace-chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-raised);
+  flex-shrink: 0;
+}
+
+.workspace-chat-title {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.workspace-chat-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.workspace-chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+.workspace-chat-welcome {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  text-align: center;
+  color: var(--text-muted);
+  gap: 12px;
+}
+
+.workspace-chat-welcome-icon {
+  font-size: 48px;
+  opacity: 0.5;
+}
+
+.workspace-chat-welcome-text {
+  max-width: 360px;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.workspace-msg {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 16px;
+  animation: fadeIn 0.2s ease;
+}
+
+.workspace-msg-avatar {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  border-radius: 50%;
+  background: var(--bg-raised);
+}
+
+.workspace-msg-content {
+  flex: 1;
+  font-size: 14px;
+  line-height: 1.6;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+.workspace-msg-content code {
+  background: var(--bg-raised);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+
+.workspace-msg-content pre {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px;
+  overflow-x: auto;
+  margin: 8px 0;
+}
+
+.workspace-msg-content pre code {
+  background: none;
+  padding: 0;
+}
+
+.workspace-msg-content strong {
+  font-weight: 600;
+}
+
+.workspace-streaming {
+  animation: blink 1s step-end infinite;
+}
+
+.workspace-error {
+  color: var(--danger);
+  padding: 8px 12px;
+  background: var(--danger-bg);
+  border-radius: 6px;
+  font-size: 13px;
+}
+
+.workspace-chat-input-bar {
+  display: flex;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-raised);
+  flex-shrink: 0;
+}
+
+.workspace-chat-input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 14px;
+  resize: none;
+  outline: none;
+  min-height: 40px;
+  max-height: 120px;
+}
+
+.workspace-chat-input:focus {
+  border-color: var(--primary);
+}
+
+.workspace-chat-input:disabled {
+  opacity: 0.6;
+}
+
+
+@keyframes blink {
+  50% { opacity: 0; }
+}
+
+/* ── Editor Divider ─────────────────────────── */
+.workspace-editor-divider {
+  width: 6px;
+  cursor: col-resize;
+  flex-shrink: 0;
+  background: var(--border);
+  transition: background 0.15s;
+  position: relative;
+  z-index: 10;
+}
+
+.workspace-editor-divider:hover,
+.workspace-editor-divider.active {
+  background: var(--primary);
+}
+
+/* ── Files Divider ──────────────────────────── */
+.workspace-files-divider {
+  width: 6px;
+  cursor: col-resize;
+  flex-shrink: 0;
+  background: var(--border);
+  transition: background 0.15s;
+  position: relative;
+  z-index: 10;
+}
+
+.workspace-files-divider:hover,
+.workspace-files-divider.active {
+  background: var(--primary);
+}

--- a/src/index.html
+++ b/src/index.html
@@ -56,6 +56,7 @@
         <a href="#usage" class="nav-link" data-page="usage" data-i18n="topbar.usage">Usage</a>
         <a href="#logs" class="nav-link" data-page="logs" data-i18n="topbar.logs">Logs</a>
         <a href="#skills" class="nav-link" data-page="skills" data-i18n="topbar.skills">Skills</a>
+        <a href="#workspace" class="nav-link" data-page="workspace" data-i18n="topbar.workspace">Workspace</a>
         <a href="#files" class="nav-link" data-page="files" data-i18n="topbar.files">Files</a>
         <a href="#mcp" class="nav-link" data-page="mcp" data-i18n="topbar.mcp">MCP</a>
         <a href="#maintenance" class="nav-link" data-page="maintenance" data-i18n="topbar.maintenance">Maintenance</a>
@@ -104,6 +105,7 @@
       <div id="page-logs" class="page"></div>
       <div id="page-maintenance" class="page"></div>
       <div id="page-files" class="page"></div>
+      <div id="page-workspace" class="page"></div>
       <div id="page-office" class="page"></div>
       <div id="page-mcp" class="page"></div>
     </main>

--- a/src/js/core/navigation.js
+++ b/src/js/core/navigation.js
@@ -11,6 +11,7 @@ import { loadSkills } from '../pages/skills.js';
 import { loadUsage } from '../pages/usage.js';
 import { loadUsersPage } from '../pages/users.js';
 import { loadMcp } from '../pages/mcp.js';
+import { loadWorkspace } from '../pages/workspace.js';
 
 function navigate(page, params = {}) {
   // Cleanup previous page resources
@@ -81,6 +82,9 @@ async function loadPage(page, params = {}) {
         break;
       case 'mcp':
         await loadMcp(container);
+        break;
+      case 'workspace':
+        await loadWorkspace(container);
         break;
       default:
         container.innerHTML = `<div class="empty" data-i18n="auto.pageNotFound">Page not found</div>`;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -28,6 +28,7 @@ import { loadMcp, showAddMcpModal, mcpAction, mcpSwitchTab, showMcpTestModal,
   showEditMcpConfigModal, submitAddMcp, submitMcpTest, submitMcpConfigEdit,
   selectMcpServer, toggleMcpAddType, renderServerListFiltered,
   toggleMcpLogs, clearMcpLogs } from './pages/mcp.js';
+import { loadWorkspace } from './pages/workspace.js';
 
 // ========================================================
 // WINDOW BRIDGE — all module exports exposed globally

--- a/src/js/pages/workspace.js
+++ b/src/js/pages/workspace.js
@@ -1,0 +1,478 @@
+import { state, t } from '../core/state.js';
+import { api } from '../core/api.js';
+import { escapeHtml } from '../core/utils.js';
+import { showToast } from '../components/toast.js';
+
+// ── State ───────────────────────────────────────────────────────────────
+let _workspacePath = '';
+let _currentDir = '/';
+let _chatMessages = [];
+let _streamActive = false;
+let _abortController = null;
+let _currentFile = null;
+let _editorDirty = false;
+
+// ── Page Load ───────────────────────────────────────────────────────────
+async function loadWorkspace(container) {
+  container.innerHTML = `
+    <div class="workspace-layout">
+      <div class="workspace-header">
+        <div class="workspace-path-bar">
+          <input type="text" id="workspace-path-input"
+            class="workspace-path-input"
+            placeholder="Enter workspace path, e.g. /home/dpatel/my-project"
+            spellcheck="false" />
+          <button class="btn btn-primary" id="workspace-set-btn" onclick="setWorkspace()">Set Workspace</button>
+          <button class="btn btn-ghost" id="workspace-browse-btn" onclick="browseWorkspace()" title="Open in Files panel">📂</button>
+        </div>
+        <div class="workspace-info" id="workspace-info"></div>
+      </div>
+      <div class="workspace-body">
+        <div class="workspace-files-panel" id="workspace-files-panel">
+          <div class="workspace-files-header">
+            <span class="workspace-files-title" id="workspace-files-title">Files</span>
+            <button class="btn btn-ghost btn-xs" id="workspace-files-refresh" onclick="refreshFileTree()" title="Refresh">🔄</button>
+          </div>
+          <div class="workspace-file-tree" id="workspace-file-tree">
+            <div class="workspace-empty" data-i18n="workspace.setPath">Set a workspace directory above to view files</div>
+          </div>
+        </div>
+        <div class="workspace-files-divider" id="workspace-files-divider"></div>
+        <!-- Editor panel (hidden when no file selected) -->
+        <div class="workspace-editor-panel" id="workspace-editor-panel" style="display:none;">
+          <div class="workspace-editor-header">
+            <span class="workspace-editor-filename" id="workspace-editor-filename"></span>
+            <div class="workspace-editor-actions">
+              <span class="workspace-editor-status" id="workspace-editor-status"></span>
+              <button class="btn btn-primary btn-xs" id="workspace-editor-save" onclick="saveWsFile()">💾 Save</button>
+              <button class="btn btn-ghost btn-xs" onclick="closeWsEditor()">✕</button>
+            </div>
+          </div>
+          <textarea class="workspace-editor-textarea" id="workspace-editor-textarea"
+            spellcheck="false" wrap="off"></textarea>
+        </div>
+        <div class="workspace-editor-divider" id="workspace-editor-divider"></div>
+        <!-- Chat panel -->
+        <div class="workspace-chat-panel">
+            <div class="workspace-chat-header">
+              <span class="workspace-chat-title">Workspace Chat</span>
+              <div class="workspace-chat-actions">
+                <button class="btn btn-ghost btn-xs" onclick="clearWsChat()" title="Clear chat">🗑️</button>
+              </div>
+            </div>
+            <div class="workspace-chat-messages" id="workspace-chat-messages">
+              <div class="workspace-chat-welcome">
+                <div class="workspace-chat-welcome-icon">💻</div>
+                <div class="workspace-chat-welcome-text">
+                  Set a workspace directory, then ask Hermes to interrogate code, fix bugs, or refactor.
+                </div>
+              </div>
+            </div>
+            <div class="workspace-chat-input-bar">
+              <textarea id="workspace-chat-input"
+                class="workspace-chat-input"
+                placeholder="Ask Hermes to work on this codebase..."
+                rows="2"
+                spellcheck="false"></textarea>
+              <button class="btn btn-primary" id="workspace-chat-send" onclick="sendWsChat()">Send</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+
+  // Load current workspace
+  try {
+    const res = await api('/api/workspace');
+    if (res.ok && res.path) {
+      _workspacePath = res.path;
+      document.getElementById('workspace-path-input').value = _workspacePath;
+      updateWsInfo();
+      await loadWsFileTree('/');
+    }
+  } catch {}
+
+  // Enter to send
+  const input = document.getElementById('workspace-chat-input');
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      sendWsChat();
+    }
+  });
+
+  // ── Divider Drag Handlers ──────────────────────────────────────────
+  setupDividerDrag('workspace-files-divider', 'workspace-files-panel', 'width', 'ws-files-width', 120);
+  setupDividerDrag('workspace-editor-divider', 'workspace-editor-panel', 'width', null, 200);
+
+  // Track editor changes
+  document.getElementById('workspace-editor-textarea').addEventListener('input', onEditorInput);
+  // Ctrl+S to save
+  document.addEventListener('keydown', onEditorKeydown);
+}
+
+function onEditorInput(e) {
+  if (_currentFile) {
+    _editorDirty = e.target.value !== _currentFile.originalContent;
+    updateWsEditorStatus();
+  }
+}
+
+function onEditorKeydown(e) {
+  if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+    if (_currentFile) { e.preventDefault(); saveWsFile(); }
+  }
+}
+
+// ── Workspace Path ──────────────────────────────────────────────────────
+window.setWorkspace = async function() {
+  const input = document.getElementById('workspace-path-input');
+  const wsPath = input.value.trim();
+  if (!wsPath) { showToast('Please enter a directory path', 'warning'); return; }
+  try {
+    const res = await api('/api/workspace', {
+      method: 'POST',
+      body: JSON.stringify({ path: wsPath }),
+      headers: { 'Content-Type': 'application/json' }
+    });
+    if (res.ok) {
+      _workspacePath = res.path;
+      input.value = res.path;
+      updateWsInfo();
+      _currentDir = '/';
+      closeWsEditor();
+      await loadWsFileTree('/');
+      showToast('Workspace set to: ' + res.path, 'success');
+    } else {
+      showToast(res.error || 'Failed to set workspace', 'error');
+    }
+  } catch (e) { showToast('Error: ' + e.message, 'error'); }
+};
+
+window.browseWorkspace = function() {
+  if (_workspacePath) window.navigate('files');
+};
+
+function updateWsInfo() {
+  const info = document.getElementById('workspace-info');
+  if (_workspacePath) {
+    const parts = _workspacePath.split('/').filter(Boolean);
+    const name = parts[parts.length - 1] || _workspacePath;
+    info.innerHTML = `<span class="workspace-badge">📁 ${escapeHtml(name)}</span> <span class="workspace-path-text">${escapeHtml(_workspacePath)}</span>`;
+  } else {
+    info.innerHTML = '<span class="workspace-path-text muted">No workspace set</span>';
+  }
+}
+
+// ── File Tree ───────────────────────────────────────────────────────────
+window.refreshFileTree = async function() {
+  if (_workspacePath) await loadWsFileTree(_currentDir);
+};
+
+async function loadWsFileTree(dir) {
+  if (!_workspacePath) return;
+  _currentDir = dir || '/';
+  const treeEl = document.getElementById('workspace-file-tree');
+  if (!treeEl) return;
+  treeEl.innerHTML = '<div class="loading">Loading...</div>';
+
+  try {
+    const res = await api(`/api/workspace?listDir=${encodeURIComponent(_currentDir)}`);
+    if (!res.ok || !res.files || res.files.error) {
+      treeEl.innerHTML = `<div class="workspace-empty">${escapeHtml(res.files?.error || 'Failed to load files')}</div>`;
+      return;
+    }
+    const { items, parent } = res.files;
+    let html = '';
+    if (parent) {
+      html += `<div class="workspace-file-item dir" onclick="loadWsDir('${escapeHtml(parent)}')">
+        <span class="file-icon">📁</span><span class="file-name">..</span></div>`;
+    }
+    for (const item of items) {
+      const isDir = item.type === 'directory';
+      const icon = isDir ? '📁' : getWsFileIcon(item.name);
+      const childPath = _currentDir === '/' ? item.name : _currentDir + '/' + item.name;
+      const isActive = _currentFile && item.name === _currentFile.relPath.split('/').pop() && _currentDir === (_currentFile.relPath.includes('/') ? _currentFile.relPath.split('/').slice(0, -1).join('/') : '/');
+      if (isDir) {
+        html += `<div class="workspace-file-item dir" onclick="loadWsDir('${escapeHtml(childPath)}')">
+          <span class="file-icon">${icon}</span><span class="file-name">${escapeHtml(item.name)}</span></div>`;
+      } else {
+        html += `<div class="workspace-file-item file${isActive ? ' active' : ''}"
+          onclick="openWsFile('${escapeHtml(childPath)}')"
+          title="${escapeHtml(formatWsSize(item.size))}">
+          <span class="file-icon">${icon}</span><span class="file-name">${escapeHtml(item.name)}</span></div>`;
+      }
+    }
+    if (items.length === 0) html = '<div class="workspace-empty">Empty directory</div>';
+    treeEl.innerHTML = html;
+    const dirName = _currentDir === '/' ? _workspacePath.split('/').filter(Boolean).pop() || _workspacePath : _currentDir.split('/').pop();
+    document.getElementById('workspace-files-title').textContent = dirName || 'Files';
+  } catch (e) {
+    treeEl.innerHTML = `<div class="workspace-empty">Error: ${escapeHtml(e.message)}</div>`;
+  }
+}
+
+window.loadWsDir = async function(dir) {
+  await loadWsFileTree(dir);
+};
+
+// ── File Editor ─────────────────────────────────────────────────────────
+window.openWsFile = async function(filePath) {
+  if (!_workspacePath) return;
+
+  // Prompt to save unsaved changes
+  if (_editorDirty && _currentFile) {
+    const save = await window.customConfirm('Save changes to ' + _currentFile.relPath + '?');
+    if (save) await saveWsFile();
+    closeWsEditor();
+  }
+
+  try {
+    const res = await fetch(`/api/workspace/file?path=${encodeURIComponent(filePath)}`, {
+      headers: { 'X-CSRF-Token': window.__csrfToken || '' }
+    });
+    const data = await res.json();
+    if (!res.ok || !data.ok) {
+      showToast(data.error || 'Failed to load file', 'error');
+      return;
+    }
+
+    _currentFile = { relPath: filePath, content: data.content, originalContent: data.content };
+    _editorDirty = false;
+
+    const editorPanel = document.getElementById('workspace-editor-panel');
+    editorPanel.style.display = 'flex';
+    const ed = document.getElementById('workspace-editor-divider');
+    if (ed) ed.style.display = '';
+    document.getElementById('workspace-editor-filename').textContent = filePath;
+    document.getElementById('workspace-editor-textarea').value = data.content;
+    updateWsEditorStatus();
+
+    // Re-render tree to highlight active file
+    await loadWsFileTree(_currentDir);
+  } catch (e) {
+    showToast('Error: ' + e.message, 'error');
+  }
+};
+
+window.saveWsFile = async function() {
+  if (!_currentFile) return;
+  const content = document.getElementById('workspace-editor-textarea').value;
+  try {
+    const res = await fetch('/api/workspace/file', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.__csrfToken || '' },
+      body: JSON.stringify({ path: _currentFile.relPath, content })
+    });
+    const data = await res.json();
+    if (data.ok) {
+      _currentFile.originalContent = content;
+      _currentFile.content = content;
+      _editorDirty = false;
+      updateWsEditorStatus();
+      showToast('Saved: ' + _currentFile.relPath, 'success');
+    } else {
+      showToast(data.error || 'Save failed', 'error');
+    }
+  } catch (e) { showToast('Error: ' + e.message, 'error'); }
+};
+
+window.closeWsEditor = function() {
+  if (_editorDirty && _currentFile) {
+    window.customConfirm('Discard unsaved changes?').then(confirmed => {
+      if (confirmed) { _currentFile = null; _editorDirty = false; hideWsEditor(); }
+    });
+  } else {
+    _currentFile = null;
+    _editorDirty = false;
+    hideWsEditor();
+  }
+};
+
+function hideWsEditor() {
+  document.getElementById('workspace-editor-panel').style.display = 'none';
+  const ed = document.getElementById('workspace-editor-divider');
+  if (ed) ed.style.display = 'none';
+  loadWsFileTree(_currentDir);
+}
+
+function updateWsEditorStatus() {
+  const statusEl = document.getElementById('workspace-editor-status');
+  if (!statusEl) return;
+  if (_editorDirty) {
+    statusEl.textContent = '● unsaved';
+    statusEl.className = 'workspace-editor-status dirty';
+  } else {
+    statusEl.textContent = '✓ saved';
+    statusEl.className = 'workspace-editor-status clean';
+  }
+}
+
+// ── Chat ────────────────────────────────────────────────────────────────
+window.sendWsChat = async function() {
+  const input = document.getElementById('workspace-chat-input');
+  const message = input.value.trim();
+  if (!message || _streamActive) return;
+  if (!_workspacePath) { showToast('Set a workspace directory first', 'warning'); return; }
+
+  _streamActive = true;
+  input.value = '';
+  input.disabled = true;
+  document.getElementById('workspace-chat-send').disabled = true;
+
+  const welcomeEl = document.querySelector('.workspace-chat-welcome');
+  if (welcomeEl) welcomeEl.style.display = 'none';
+
+  appendWsMsg('user', message);
+  const msgId = appendWsMsg('assistant', '<div class="workspace-streaming">▊</div>');
+
+  _abortController = new AbortController();
+  try {
+    const resp = await fetch('/api/chat/send', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.__csrfToken || '' },
+      body: JSON.stringify({ message, workspace: _workspacePath, profile: 'default' }),
+      signal: _abortController.signal
+    });
+    if (!resp.ok) {
+      updateWsMsg(msgId, `<div class="workspace-error">Error: ${resp.status} ${resp.statusText}</div>`);
+      _streamActive = false; input.disabled = false; document.getElementById('workspace-chat-send').disabled = false;
+      return;
+    }
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let fullText = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const chunk = decoder.decode(value, { stream: true });
+      for (const line of chunk.split('\n')) {
+        if (!line.startsWith('data: ')) continue;
+        try {
+          const data = JSON.parse(line.slice(6));
+          if (data.type === 'token') { fullText += data.content; updateWsMsg(msgId, formatWsContent(fullText)); }
+          else if (data.type === 'done') { updateWsMsg(msgId, formatWsContent(fullText)); }
+          else if (data.type === 'error') { updateWsMsg(msgId, `<div class="workspace-error">${escapeHtml(data.content)}</div>`); }
+        } catch {}
+      }
+    }
+  } catch (e) {
+    if (e.name !== 'AbortError') updateWsMsg(msgId, `<div class="workspace-error">Error: ${escapeHtml(e.message)}</div>`);
+  }
+  _streamActive = false; input.disabled = false; document.getElementById('workspace-chat-send').disabled = false;
+  input.focus();
+  document.getElementById('workspace-chat-messages').scrollTop = document.getElementById('workspace-chat-messages').scrollHeight;
+};
+
+window.clearWsChat = function() {
+  const msgsEl = document.getElementById('workspace-chat-messages');
+  msgsEl.innerHTML = `<div class="workspace-chat-welcome">
+    <div class="workspace-chat-welcome-icon">💻</div>
+    <div class="workspace-chat-welcome-text">
+      Set a workspace directory, then ask Hermes to interrogate code, fix bugs, or refactor.
+    </div>
+  </div>`;
+};
+
+function appendWsMsg(role, content) {
+  const msgsEl = document.getElementById('workspace-chat-messages');
+  const id = 'wsm-' + Date.now() + '-' + Math.random().toString(36).slice(2, 6);
+  const div = document.createElement('div');
+  div.className = `workspace-msg workspace-msg-${role}`;
+  div.id = id;
+  div.innerHTML = `<div class="workspace-msg-avatar">${role === 'user' ? '👤' : '🤖'}</div><div class="workspace-msg-content">${content}</div>`;
+  msgsEl.appendChild(div);
+  msgsEl.scrollTop = msgsEl.scrollHeight;
+  return id;
+}
+
+function updateWsMsg(id, content) {
+  const el = document.getElementById(id);
+  if (el) {
+    const contentEl = el.querySelector('.workspace-msg-content');
+    if (contentEl) contentEl.innerHTML = content;
+  }
+}
+
+function formatWsContent(text) {
+  let html = escapeHtml(text);
+  html = html.replace(/```(\w*)\n?([\s\S]*?)```/g, '<pre><code class="language-$1">$2</code></pre>');
+  html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+  html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  html = html.replace(/\n/g, '<br>');
+  return html;
+}
+
+// ── Divider Drag ──────────────────────────────────────────────────
+function setupDividerDrag(dividerId, targetId, cssProp, varName, minSize) {
+  const divider = document.getElementById(dividerId);
+  if (!divider) return;
+
+  let isDragging = false;
+  let startX = 0;
+  let startSize = 0;
+  const body = divider.closest('.workspace-body');
+  if (!body) return;
+
+  divider.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    isDragging = true;
+    startX = e.clientX;
+    const target = document.getElementById(targetId);
+    if (target) {
+      startSize = target.getBoundingClientRect().width;
+      target.style.flex = 'none';
+    }
+    divider.classList.add('active');
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  });
+
+  document.addEventListener('mousemove', (e) => {
+    if (!isDragging) return;
+    const target = document.getElementById(targetId);
+    if (!target) return;
+    const dx = e.clientX - startX;
+    const bodyRect = body.getBoundingClientRect();
+    const maxSize = bodyRect.width * 0.5;
+    let newSize = Math.max(minSize, Math.min(maxSize, startSize + dx));
+    target.style.width = newSize + 'px';
+    if (varName) {
+      body.style.setProperty('--' + varName, newSize + 'px');
+    }
+  });
+
+  document.addEventListener('mouseup', () => {
+    if (isDragging) {
+      isDragging = false;
+      divider.classList.remove('active');
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    }
+  });
+}
+
+// ── Utilities ───────────────────────────────────────────────────────────
+function getWsFileIcon(name) {
+  const ext = name.split('.').pop().toLowerCase();
+  const m = {
+    js: '🟨', jsx: '⚛️', ts: '🔵', tsx: '⚛️', py: '🐍',
+    json: '📋', yaml: '📋', yml: '📋', md: '📝', txt: '📄',
+    html: '🌐', css: '🎨', sh: '💻', bash: '💻',
+    c: '⚙️', cpp: '⚙️', go: '🔷', rs: '🦀', java: '☕',
+    toml: '📋', xml: '📋', svg: '🖼️', gitignore: '🙈',
+    dockerfile: '🐳', png: '🖼️', jpg: '🖼️', gif: '🖼️'
+  };
+  return m[ext] || '📄';
+}
+
+function formatWsSize(bytes) {
+  if (!bytes) return '';
+  const u = ['B', 'KB', 'MB', 'GB'];
+  let i = 0; let s = bytes;
+  while (s >= 1024 && i < u.length - 1) { s /= 1024; i++; }
+  return s.toFixed(1) + ' ' + u[i];
+}
+
+export { loadWorkspace };


### PR DESCRIPTION
hat it is: A self-contained code workspace inside HCI — think a lightweight version of VS Code / Claude Code, with a file tree, code editor, and dedicated chat that all operate within a single project directory.
 
<img width="1899" height="908" alt="Workspace" src="https://github.com/user-attachments/assets/6f935256-f121-4d2a-888e-814772c86455" />

    - Workspace path bar — text input at the top where you enter / paste a project directory path. Clicking "Set" saves it and immediately loads the file tree. The 📂 button switches you to HCI's existing Files panel if you prefer that view.
    
    - File tree (left panel) — lists files/directories in the workspace. Directories are clickable to drill down, parent .. to go back. Each file gets a coloured icon based on extension (🐍 for .py, 🟨 for .js, 🌐 for .html, etc.). Shows file sizes on hover.
    
    - Code editor (middle panel) — hidden by default, appears when you click a file. It's a <textarea> with monospace font, no-wrap, spellcheck off. Shows a dirty indicator (● unsaved / ✓ saved) that updates live as you type. Ctrl+S saves back to disk via the HCI API. Closing the editor prompts to save/discard unsaved changes.
    
    - Divider drag handles — two draggable vertical bars between the panels (file tree ↔ editor, editor ↔ chat). Built with mousedown/mousemove/mouseup handlers, clamped between a minimum size (~120px for files, ~200px for editor) and 50% of the body width. The dragged panel switches to flex: none so it holds an explicit pixel width.
    
    - Workspace Chat (right panel) — dedicated chat that sends queries to Hermes with the workspace path baked in. Features:
      - Streaming responses — reads from a ReadableStream SSE endpoint, renders tokens live as they arrive
      - Markdown rendering — inline code (\...\), code blocks (...), bold (text)
      - Enter to send, Shift+Enter for newline
      - Clear chat button (🗑️)
      - Welcome placeholder text when no workspace is set
    
    - Server-side API — backed by two endpoints:
      - POST /api/workspace — sets and validates the workspace directory
      - GET /api/workspace?listDir=<path> — lists directory contents
      - GET /api/workspace/file?path=<path> — reads a file
      - POST /api/workspace/file — writes/saves a file (with CSRF protection)
      - POST /api/chat/send — sends a message to Hermes with the workspace context, streaming back SSE tokens
    
    - Persistence — the workspace path is saved to ~/.hermes/workspace.json on the server so it survives page refreshes.
