### PR TITLE
feat: Profile-Based Access Control (per-agent user isolation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,24 @@ Full operational control plane — list, start, stop, restart MCP servers. Live 
 - Rate limiting (global + chat), WebSocket RBAC
 - Path traversal prevention, XSS protection
 - 20 permissions across 3 roles (admin, viewer, custom)
+- **Profile-based access isolation** — restrict users to specific agent profiles
+
+### Profile-Based Access Control
+
+Multi-agent teams can restrict which profiles (agents) each user can see and manage:
+
+```javascript
+// User creation with profile restriction
+createUser('cx-team', 'password', 'custom', ['jorah']);     // only sees Jorah
+createUser('influencer-team', 'password', 'custom', ['varys']); // only sees Varys  
+createUser('admin', 'password', 'admin', ['*']);             // sees all agents
+```
+
+- `allowed_profiles` field on each user (`["*"]` = full access, `["jorah", "varys"]` = specific agents)
+- Filters `/api/profiles`, `/api/office/agent-states`, and all `:profile` endpoints
+- `requireProfileAccess` middleware on gateway, config, and keys routes
+- Profile selection UI in the Create User form (checkboxes for available agents)
+- Nav tabs hidden based on user permissions (Files, Maintenance = admin only)
 
 ### PWA
 

--- a/auth.js
+++ b/auth.js
@@ -47,7 +47,7 @@ function findUser(username) {
   return data.users.find(u => u.username === username) || null;
 }
 
-function createUser(username, password, role = 'viewer') {
+function createUser(username, password, role = 'viewer', allowed_profiles = ['*']) {
   const clean = sanitizeUsername(username);
   if (!clean) return { ok: false, error: 'Invalid username (2-32 chars, alphanumeric/_.- only)' };
   const data = loadUsers();
@@ -59,12 +59,29 @@ function createUser(username, password, role = 'viewer') {
     username: clean,
     password_hash: hash,
     role,
+    allowed_profiles: role === 'admin' ? ['*'] : allowed_profiles,
     created_at: new Date().toISOString(),
     last_login: null,
   });
   saveUsers(data);
-  audit('system', 'admin', 'USER_CREATE', `created user ${clean} (${role})`);
+  audit('system', 'admin', 'USER_CREATE', `created user ${clean} (${role}) profiles=${JSON.stringify(allowed_profiles)}`);
   return { ok: true };
+}
+
+function updateUserProfiles(username, allowed_profiles, currentUser) {
+  const data = loadUsers();
+  const user = data.users.find(u => u.username === username);
+  if (!user) return { ok: false, error: 'User not found' };
+  user.allowed_profiles = allowed_profiles;
+  saveUsers(data);
+  audit(currentUser, 'admin', 'USER_UPDATE_PROFILES', `${username} profiles=${JSON.stringify(allowed_profiles)}`);
+  return { ok: true };
+}
+
+function canAccessProfile(user, profileName) {
+  if (!user || !user.allowed_profiles) return true; // legacy users get full access
+  if (user.allowed_profiles.includes('*')) return true;
+  return user.allowed_profiles.includes(profileName);
 }
 
 function deleteUser(username, currentUser) {
@@ -275,6 +292,8 @@ module.exports = {
   sanitizeUsername,
   listUsers,
   updateUserPermissions,
+  updateUserProfiles,
+  canAccessProfile,
   PERMISSIONS,
   PRESET_PERMISSIONS,
   resolvePermissions,

--- a/server.js
+++ b/server.js
@@ -937,6 +937,17 @@ function requireAuth(req, res, next) {
   return res.status(401).json({ error: 'authentication required' });
 }
 
+function requireProfileAccess(req, res, next) {
+  const profile = req.params.profile || req.body?.profile;
+  if (!profile) return next();
+  const currentUser = getCurrentUser(req);
+  const user = currentUser ? findUser(currentUser.username) : null;
+  if (!canAccessProfile(user, profile)) {
+    return res.status(403).json({ error: 'access denied to this profile' });
+  }
+  return next();
+}
+
 function requireCsrf(req, res, next) {
   if (!isAuthed(req)) return res.status(401).json({ error: 'authentication required' });
   const headerToken = req.headers['x-csrf-token'];
@@ -1840,7 +1851,7 @@ app.get('/api/session', requireAuth, (req, res) => {
 const {
   isFirstRun, findUser, createUser, deleteUser,
   verifyUserPassword, changePassword, resetUserPassword, sanitizeUsername, listUsers,
-  updateUserPermissions, PERMISSIONS, PRESET_PERMISSIONS, resolvePermissions,
+  updateUserPermissions, updateUserProfiles, canAccessProfile, PERMISSIONS, PRESET_PERMISSIONS, resolvePermissions,
   audit, getAuditLog,
   loadNotifications, addNotification, dismissNotification, clearNotifications,
 } = require('./auth');
@@ -2388,8 +2399,10 @@ getProfiles.cache = { at: 0, data: [] };
 
 app.get('/api/profiles', requireAuth, async (req, res) => {
   const profiles = await getProfiles();
-  console.log('[DEBUG /api/profiles] returning:', JSON.stringify(profiles));
-  res.json({ ok: true, profiles });
+  const user = findUser(req.session?.username);
+  const filtered = profiles.filter(p => canAccessProfile(user, p.name || p));
+  console.log('[DEBUG /api/profiles] returning:', JSON.stringify(filtered));
+  res.json({ ok: true, profiles: filtered });
 });
 
 app.post('/api/profiles/use', requireRole('admin'), requireCsrf, async (req, res) => {
@@ -2420,7 +2433,7 @@ function getGatewayServiceName(profile) {
   };
 }
 
-app.get('/api/gateway/:profile', requireAuth, async (req, res) => {
+app.get('/api/gateway/:profile', requireAuth, requireProfileAccess, async (req, res) => {
   const profile = sanitizeProfileName(req.params.profile);
   if (!profile) return res.status(400).json({ error: 'invalid profile name' });
   const svcs = getGatewayServiceName(profile);
@@ -2474,7 +2487,7 @@ app.get('/api/gateway/:profile', requireAuth, async (req, res) => {
 });
 
 // Gateway connections (parse from hermes status --all)
-app.get('/api/gateway/:profile/connections', requireAuth, async (req, res) => {
+app.get('/api/gateway/:profile/connections', requireAuth, requireProfileAccess, async (req, res) => {
   const profile = sanitizeProfileName(req.params.profile);
   if (!profile) return res.status(400).json({ error: 'invalid profile name' });
   try {
@@ -2571,7 +2584,7 @@ app.post('/api/gateway/:profile/:action', requireAuth, requireRole('admin'), req
   }
 });
 
-app.get('/api/gateway/:profile/logs', requireAuth, async (req, res) => {
+app.get('/api/gateway/:profile/logs', requireAuth, requireProfileAccess, async (req, res) => {
   const profile = sanitizeProfileName(req.params.profile);
   if (!profile) return res.status(400).json({ error: 'invalid profile name' });
   const svcs = getGatewayServiceName(profile);
@@ -2597,7 +2610,7 @@ app.get('/api/gateway/:profile/logs', requireAuth, async (req, res) => {
 });
 
 // Gateway health check for a specific profile
-app.get('/api/gateway/:profile/health', requireAuth, async (req, res) => {
+app.get('/api/gateway/:profile/health', requireAuth, requireProfileAccess, async (req, res) => {
   try {
     const profile = sanitizeProfileName(req.params.profile) || 'default';
     const port = gatewayPorts[profile];
@@ -3383,7 +3396,10 @@ app.get('/api/office/agent-states', requireAuth, async (req, res) => {
       agents.push(agent);
     }
 
-    res.json({ ok: true, agents, timestamp: Date.now() });
+    const currentUser = getCurrentUser(req);
+    const user = currentUser ? findUser(currentUser.username) : null;
+    const filteredAgents = agents.filter(a => canAccessProfile(user, a.name || a.profile));
+    res.json({ ok: true, agents: filteredAgents, timestamp: Date.now() });
   } catch (e) {
     res.json({ ok: false, error: e.message });
   }
@@ -4172,7 +4188,7 @@ app.get('/api/skills', requireAuth, async (req, res) => {
 });
 
 // Config show
-app.get('/api/config/:profile', requireAuth, async (req, res) => {
+app.get('/api/config/:profile', requireAuth, requireProfileAccess, async (req, res) => {
   try {
     const profile = sanitizeProfileName(req.params.profile);
     if (!profile) return res.status(400).json({ ok: false, error: 'invalid profile name' });
@@ -4331,7 +4347,7 @@ function getKeyMeta(name) {
 }
 
 // Keys (secrets) — list keys from .env with category metadata
-app.get('/api/keys/:profile', requireAuth, async (req, res) => {
+app.get('/api/keys/:profile', requireAuth, requireProfileAccess, async (req, res) => {
   try {
     const profile = sanitizeProfileName(req.params.profile);
     if (!profile) return res.status(400).json({ ok: false, error: 'invalid profile name' });

--- a/server.js
+++ b/server.js
@@ -2029,7 +2029,7 @@ app.get('/api/users', requireRole('admin'), (req, res) => {
 
 // Create user
 app.post('/api/users', requireRole('admin'), requireCsrf, (req, res) => {
-  const { username, password, role, permissions } = req.body || {};
+  const { username, password, role, permissions, allowed_profiles } = req.body || {};
   if (!username || !password) {
     return res.status(400).json({ ok: false, error: 'Username and password required' });
   }
@@ -2040,9 +2040,10 @@ app.post('/api/users', requireRole('admin'), requireCsrf, (req, res) => {
     return res.status(400).json({ ok: false, error: 'Password must be at least 8 characters' });
   }
   const userRole = ['admin', 'viewer', 'custom'].includes(role) ? role : 'viewer';
-  const result = createUser(username, password, userRole, userRole === 'custom' ? permissions : null);
+  const profiles = userRole === 'admin' ? ['*'] : (Array.isArray(allowed_profiles) ? allowed_profiles : ['*']);
+  const result = createUser(username, password, userRole, profiles);
   if (!result.ok) return res.status(400).json(result);
-  addNotification('success', `User created: ${username} (${userRole})`);
+  addNotification('success', `User created: ${username} (${userRole}) profiles=${JSON.stringify(profiles)}`);
   res.json({ ok: true });
 });
 

--- a/server.js
+++ b/server.js
@@ -2400,7 +2400,8 @@ getProfiles.cache = { at: 0, data: [] };
 
 app.get('/api/profiles', requireAuth, async (req, res) => {
   const profiles = await getProfiles();
-  const user = findUser(req.session?.username);
+  const currentUser = getCurrentUser(req);
+  const user = currentUser ? findUser(currentUser.username) : null;
   const filtered = profiles.filter(p => canAccessProfile(user, p.name || p));
   console.log('[DEBUG /api/profiles] returning:', JSON.stringify(filtered));
   res.json({ ok: true, profiles: filtered });

--- a/src/index.html
+++ b/src/index.html
@@ -57,9 +57,9 @@
         <a href="#logs" class="nav-link" data-page="logs" data-i18n="topbar.logs">Logs</a>
         <a href="#skills" class="nav-link" data-page="skills" data-i18n="topbar.skills">Skills</a>
         <a href="#workspace" class="nav-link" data-page="workspace" data-i18n="topbar.workspace">Workspace</a>
-        <a href="#files" class="nav-link" data-page="files" data-i18n="topbar.files">Files</a>
+        <a href="#files" class="nav-link" id="nav-files" data-page="files" data-i18n="topbar.files">Files</a>
         <a href="#mcp" class="nav-link" data-page="mcp" data-i18n="topbar.mcp">MCP</a>
-        <a href="#maintenance" class="nav-link" data-page="maintenance" data-i18n="topbar.maintenance">Maintenance</a>
+        <a href="#maintenance" class="nav-link" id="nav-maintenance" data-page="maintenance" data-i18n="topbar.maintenance">Maintenance</a>
       </nav>
       <div class="topbar-right">
         <button class="icon-btn" id="notif-btn" title="Notifications" data-i18n-title="topbar.notifications" onclick="toggleNotifDropdown()">

--- a/src/js/core/auth.js
+++ b/src/js/core/auth.js
@@ -58,15 +58,10 @@ function showApp() {
 
   // Hide nav items based on permissions (after DOM is visible)
   setTimeout(() => {
-    const navPerms = { 'files': 'files.read', 'maintenance': 'admin' };
-    document.querySelectorAll('.nav-link[data-page]').forEach(link => {
-      const page = link.getAttribute('data-page');
-      const req = navPerms[page];
-      if (req) {
-        const show = req === 'admin' ? state.user?.role === 'admin' : hasPerm(req);
-        link.style.display = show ? '' : 'none';
-      }
-    });
+    const navFiles = document.getElementById('nav-files');
+    const navMaint = document.getElementById('nav-maintenance');
+    if (navFiles && !hasPerm('files.read')) navFiles.style.display = 'none';
+    if (navMaint && state.user?.role !== 'admin') navMaint.style.display = 'none';
   }, 100);
 
   // ── Phase 3: Session Restore ──

--- a/src/js/core/auth.js
+++ b/src/js/core/auth.js
@@ -1,4 +1,5 @@
 import { state, t, wsClient } from './state.js';;
+import { hasPerm } from './permissions.js';
 import { updateGatewayBadge, updateWsConnectionUI } from '../chat/cli.js';
 import { loadChatSession } from '../chat/core.js';
 import { setupWsChatHandlers, showChatWarning } from '../chat/gateway.js';
@@ -52,6 +53,24 @@ function showApp() {
   document.getElementById('login-overlay').classList.add('hidden');
   document.getElementById('app').style.display = 'block';
   updateUserMenu();
+
+  // Hide nav items based on permissions
+  const navPerms = {
+    'files': 'files.read',
+    'maintenance': 'admin',
+  };
+  document.querySelectorAll('.nav-link[data-page]').forEach(link => {
+    const page = link.getAttribute('data-page');
+    const requiredPerm = navPerms[page];
+    if (requiredPerm) {
+      if (requiredPerm === 'admin') {
+        link.style.display = (state.user?.role === 'admin') ? '' : 'none';
+      } else {
+        link.style.display = hasPerm(requiredPerm) ? '' : 'none';
+      }
+    }
+  });
+
   navigate(state.page);
   startNotifPolling();
 

--- a/src/js/core/auth.js
+++ b/src/js/core/auth.js
@@ -53,26 +53,21 @@ function showApp() {
   document.getElementById('login-overlay').classList.add('hidden');
   document.getElementById('app').style.display = 'block';
   updateUserMenu();
-
-  // Hide nav items based on permissions
-  const navPerms = {
-    'files': 'files.read',
-    'maintenance': 'admin',
-  };
-  document.querySelectorAll('.nav-link[data-page]').forEach(link => {
-    const page = link.getAttribute('data-page');
-    const requiredPerm = navPerms[page];
-    if (requiredPerm) {
-      if (requiredPerm === 'admin') {
-        link.style.display = (state.user?.role === 'admin') ? '' : 'none';
-      } else {
-        link.style.display = hasPerm(requiredPerm) ? '' : 'none';
-      }
-    }
-  });
-
   navigate(state.page);
   startNotifPolling();
+
+  // Hide nav items based on permissions (after DOM is visible)
+  setTimeout(() => {
+    const navPerms = { 'files': 'files.read', 'maintenance': 'admin' };
+    document.querySelectorAll('.nav-link[data-page]').forEach(link => {
+      const page = link.getAttribute('data-page');
+      const req = navPerms[page];
+      if (req) {
+        const show = req === 'admin' ? state.user?.role === 'admin' : hasPerm(req);
+        link.style.display = show ? '' : 'none';
+      }
+    });
+  }, 100);
 
   // ── Phase 3: Session Restore ──
   // Restore last session from localStorage after sidebar loads

--- a/src/js/core/auth.js
+++ b/src/js/core/auth.js
@@ -5,7 +5,6 @@ import { loadChatSession } from '../chat/core.js';
 import { setupWsChatHandlers, showChatWarning } from '../chat/gateway.js';
 import { startNotifPolling } from '../components/notifications.js';
 import { navigate } from './navigation.js';
-import { hasPerm } from './permissions.js';
 
 async function checkAuth() {
   try {

--- a/src/js/pages/users.js
+++ b/src/js/pages/users.js
@@ -223,6 +223,13 @@ async function showCreateUser() {
             </div>
           </div>
         </div>
+        <div style="margin-bottom:10px;">
+          <label style="font-size:11px;color:var(--fg-muted);display:block;margin-bottom:6px;">Agent Access (allowed profiles)</label>
+          <div style="font-size:10px;color:var(--fg-subtle);margin-bottom:6px;">Uncheck agents this user should NOT see. Admin role always sees all.</div>
+          <div id="profile-access-list" style="display:grid;grid-template-columns:1fr 1fr;gap:2px;font-size:11px;border:1px solid var(--border);border-radius:var(--radius);padding:8px;background:var(--bg-input);">
+            <span style="color:var(--fg-muted);font-size:10px;">Loading profiles...</span>
+          </div>
+        </div>
         <div class="modal-actions">
           <button type="button" class="btn btn-ghost" onclick="this.closest('.modal-overlay').remove()" data-i18n="auto.cancel">Cancel</button>
           <button type="submit" class="btn btn-primary" data-i18n="auto.createUser">Create User</button>
@@ -231,6 +238,22 @@ async function showCreateUser() {
     </div>
   `;
   document.body.appendChild(overlay);
+
+  // Load available profiles for the allowed_profiles selector
+  (async () => {
+    try {
+      const profilesRes = await api('/api/profiles');
+      const profiles = (profilesRes.profiles || []).map(p => p.name || p);
+      const container = overlay.querySelector('#profile-access-list');
+      if (container && profiles.length) {
+        container.innerHTML = profiles.map(name => `
+          <label style="display:flex;align-items:center;gap:4px;cursor:pointer;padding:2px 4px;border-radius:3px;" onmouseover="this.style.background='var(--bg-panel-hover)'" onmouseout="this.style.background='transparent'">
+            <input type="checkbox" name="allowed_profile" value="${name}" checked /> ${name}
+          </label>
+        `).join('');
+      }
+    } catch(_) {}
+  })();
 
   // Apply preset for create user modal
   const form = overlay.querySelector('#create-user-form');
@@ -286,15 +309,18 @@ async function showCreateUser() {
       const checked = overlay.querySelectorAll('input[name="perm"]:checked');
       checked.forEach(cb => { perms[cb.value] = true; });
     }
-    createUser(username, password, role, perms);
+    // Collect allowed profiles
+    const profileChecked = overlay.querySelectorAll('input[name="allowed_profile"]:checked');
+    const allowed_profiles = role === 'admin' ? ['*'] : Array.from(profileChecked).map(cb => cb.value);
+    createUser(username, password, role, perms, allowed_profiles);
     overlay.remove();
   });
 }
 
-async function createUser(username, password, role, permissions) {
+async function createUser(username, password, role, permissions, allowed_profiles) {
   try {
     const csrfToken = state.csrfToken || '';
-    const body = { username, password, role };
+    const body = { username, password, role, allowed_profiles };
     if (role === 'custom' && permissions) body.permissions = permissions;
     const res = await api('/api/users', {
       method: 'POST',


### PR DESCRIPTION
## Summary

Adds profile-based access isolation to HCI — restrict users to specific agent profiles in multi-agent deployments.

## Changes

### Backend (auth.js + server.js)
- `allowed_profiles` field on user schema (`['*']` = all, `['jorah']` = specific)
- `canAccessProfile(user, profileName)` helper
- `requireProfileAccess` middleware on `:profile` endpoints (gateway, config, keys)
- Filter `/api/profiles` and `/api/office/agent-states` by user's allowed profiles
- `updateUserProfiles()` for managing access post-creation
- `POST /api/users` accepts `allowed_profiles` array

### Frontend (users.js + auth.js + index.html)
- Profile selection checkboxes in Create User form (loaded dynamically from `/api/profiles`)
- Admin role auto-sets `['*']`
- Nav tabs (Files, Maintenance) hidden for non-admin users based on permissions

## Use Case

Teams running multiple Hermes agents (e.g. SEO agent, Influencer agent, Support agent) can give each team member access only to their agent without exposing the others.

## Backward Compatible

Existing users without `allowed_profiles` get full access by default (graceful fallback).