### PR TITLE
fix: guard process.getuid() calls for Windows compatibility

### DIFF
--- a/server.js
+++ b/server.js
@@ -143,12 +143,12 @@ const PROJECTS_ROOT    = cfg.projectsRoot;
 const HCI_USER = os.userInfo().username;
 const HCI_HOST = os.hostname();
 const HCI_IDENTITY = `${HCI_USER}@${HCI_HOST}`;
-const IS_ROOT = process.getuid() === 0;
+const IS_ROOT = process.getuid ? process.getuid() === 0 : false;
 // systemctl/journalctl: add --user flag for non-root
 const SYSTEMD_USER_FLAG = IS_ROOT ? '' : '--user';
 // XDG_RUNTIME_DIR: required for systemctl --user to work
 // Auto-detect if not set (e.g. running via sudo -u without login session)
-if (!IS_ROOT && !process.env.XDG_RUNTIME_DIR) {
+if (!IS_ROOT && !process.env.XDG_RUNTIME_DIR && process.getuid) {
   const uid = process.getuid();
   const runtimeDir = `/run/user/${uid}`;
   if (fs.existsSync(runtimeDir)) {


### PR DESCRIPTION
## Problem

server.js calls `process.getuid()` in two places. This is a Unix-only API that throws `TypeError: process.getuid is not a function` on Windows, preventing the server from starting at all.

\\\
TypeError: process.getuid is not a function
    at Object.<anonymous> (server.js:146:25)
\\\

## Changes

Two minimal guards added to `server.js`:

**Line 146 — IS_ROOT check:**
\\\js
// before
const IS_ROOT = process.getuid() === 0;
// after
const IS_ROOT = process.getuid ? process.getuid() === 0 : false;
\\\

**Line 151 — XDG_RUNTIME_DIR auto-detect block:**
\\\js
// before
if (!IS_ROOT && !process.env.XDG_RUNTIME_DIR) {
// after
if (!IS_ROOT && !process.env.XDG_RUNTIME_DIR && process.getuid) {
\\\

`IS_ROOT` defaults to `false` on Windows (correct — no root concept). The `XDG_RUNTIME_DIR` block is a Linux-only feature and is safely skipped.

## Testing

- Windows 11, Node v24.15.0 (Scoop)
- Server starts and serves on http://127.0.0.1:10272 after the fix
- No functional change on Linux/macOS (guards are no-ops where `process.getuid` exists)

## Notes

Line 417 already uses `process.getuid?.()` (optional chaining) correctly — only lines 146 and 151 needed fixing.